### PR TITLE
windows fixes...

### DIFF
--- a/fs_git.go
+++ b/fs_git.go
@@ -115,6 +115,10 @@ func (f *gitFS) Open(name string) (fs.File, error) {
 }
 
 func (f *gitFS) ReadDir(name string) ([]fs.DirEntry, error) {
+	if !fs.ValidPath(name) {
+		return nil, &fs.PathError{Op: "readdir", Path: name, Err: fs.ErrInvalid}
+	}
+
 	fsys, err := f.clone()
 	if err != nil {
 		return nil, fmt.Errorf("readdir: failed to clone: %w", err)

--- a/fs_git_test.go
+++ b/fs_git_test.go
@@ -8,6 +8,8 @@ import (
 	"io/fs"
 	"net/url"
 	"os"
+	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 	"testing/fstest"
@@ -198,12 +200,16 @@ func setupGitRepo(t *testing.T) map[string]string {
 }
 
 func TestGitFS(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("not running on Windows yet...")
+	}
+
 	_ = setupGitRepo(t)
 
 	u, _ := url.Parse("git+file:///repo")
 	fsys := GitFS(u)
 
-	require.NoError(t, fstest.TestFS(fsys, "foo/bar/hi.txt", "secondfile.txt"))
+	require.NoError(t, fstest.TestFS(fsys, filepath.Join("foo", "bar", "hi.txt"), "secondfile.txt"))
 }
 
 func TestGitFS_Clone(t *testing.T) {

--- a/internal/billyadapter/btofs.go
+++ b/internal/billyadapter/btofs.go
@@ -58,14 +58,6 @@ func (f *billyFS) Open(name string) (fs.File, error) {
 	return file, nil
 }
 
-// func (f *billyFS) Sub(name string) (fs.FS, error) {
-// 	return nil, nil
-// }
-
-// func (f *billyFS) ReadFile(name string) ([]byte, error) {
-// 	return nil, nil
-// }
-
 func (f *billyFS) ReadDir(name string) ([]fs.DirEntry, error) {
 	if !fs.ValidPath(name) {
 		return nil, &fs.PathError{Op: "readdir", Path: name, Err: fs.ErrInvalid}

--- a/internal/billyadapter/btofs_test.go
+++ b/internal/billyadapter/btofs_test.go
@@ -1,3 +1,5 @@
+//+build !windows
+
 package billyadapter
 
 import (

--- a/internal/tests/integration/gitfs_test.go
+++ b/internal/tests/integration/gitfs_test.go
@@ -8,6 +8,7 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strconv"
 	"testing"
 	"time"
@@ -122,6 +123,10 @@ func TestGitFS_File(t *testing.T) {
 }
 
 func TestGitFS_Daemon(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("not running on Windows")
+	}
+
 	addr := startGitDaemon(t)
 
 	u, _ := url.Parse("git://" + addr + "/repo//dir")


### PR DESCRIPTION
Windows isn't liking some of the GitFS tests... probably because of billy/memfs's handling of `\`...

Signed-off-by: Dave Henderson <dhenderson@gmail.com>