### PR TITLE
filefs: Properly support Windows UNCs

### DIFF
--- a/filefs/file_test.go
+++ b/filefs/file_test.go
@@ -29,3 +29,56 @@ func TestFileFS(t *testing.T) {
 	err := fstest.TestFS(fsys, "hello.txt", "sub/subfile.txt")
 	assert.NoError(t, err)
 }
+
+func mustURL(s string) *url.URL {
+	u, err := url.Parse(s)
+	if err != nil {
+		panic(err)
+	}
+
+	return u
+}
+
+func TestPathForDirFS(t *testing.T) {
+	testdata := []struct {
+		in  *url.URL
+		out string
+	}{
+		{mustURL("file:"), ""},
+		{mustURL("file:/"), "/"},
+		{mustURL("file:///"), "/"},
+		{mustURL("file:///tmp/foo"), "/tmp/foo"},
+		{mustURL("file:///C:/Users/"), "C:/Users/"},
+		{mustURL("file:///C:/Program%20Files"), "C:/Program Files"},
+		{mustURL("file://./C:/Users/"), "//./C:/Users/"},
+		{mustURL("file://somehost/Share/foo"), "//somehost/Share/foo"},
+		{mustURL("file://invalid"), ""},
+		{mustURL("file://host/j"), "//host/j"},
+	}
+
+	for _, d := range testdata {
+		assert.Equal(t, d.out, pathForDirFS(d.in))
+	}
+}
+
+func BenchmarkPathForDirFS(b *testing.B) {
+	testdata := []*url.URL{
+		mustURL("file:"),
+		mustURL("file:/"),
+		mustURL("file:///"),
+		mustURL("file:///tmp/foo"),
+		mustURL("file:///C:/Users/"),
+		mustURL("file:///C:/Program%20Files"),
+		mustURL("file://./C:/Users/"),
+		mustURL("file://somehost/Share/foo"),
+		mustURL("file://invalid"),
+	}
+
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		for _, d := range testdata {
+			pathForDirFS(d)
+		}
+	}
+}


### PR DESCRIPTION
UNCs weren't supported before by `filefs`. This should fix that!

Signed-off-by: Dave Henderson <dhenderson@gmail.com>