### PR TITLE
Replace golint with revive

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -3,8 +3,6 @@ linters-settings:
     check-shadowing: true
     enable:
       - fieldalignment
-  golint:
-    min-confidence: 0
   gocyclo:
     min-complexity: 10
   dupl:
@@ -45,7 +43,6 @@ linters:
     - gofumpt
     - goheader
     - goimports
-    - golint
     # - gomnd
     - gomodguard
     - goprintffuncname
@@ -61,6 +58,7 @@ linters:
     - noctx
     - nolintlint
     - prealloc
+    - revive
     - rowserrcheck
     - sqlclosecheck
     - staticcheck

--- a/internal/billyadapter/frozentime.go
+++ b/internal/billyadapter/frozentime.go
@@ -7,8 +7,9 @@ import (
 	"github.com/go-git/go-billy/v5"
 )
 
-// a workaround for annoying behaviour in billy's memfs FileInfo implementation,
-// which always returns time.Now() on calls to ModTime().
+// FrozenModTimeFilesystem is a workaround for annoying behaviour in billy's
+// memfs FileInfo implementation, which always returns time.Now() on calls to
+// ModTime().
 func FrozenModTimeFilesystem(fs billy.Filesystem, modTime time.Time) billy.Filesystem {
 	return &frozenModTimeFilesystem{fs, modTime}
 }

--- a/internal/types.go
+++ b/internal/types.go
@@ -69,8 +69,7 @@ type WithHTTPClienter interface {
 	WithHTTPClient(client *http.Client) fs.FS
 }
 
-// WithHTTPHeaderer is an fs.FS that can be configured to send a custom
-// http.Header
+// WithHeaderer is an fs.FS that can be configured to send a custom http.Header
 type WithHeaderer interface {
 	WithHeader(headers http.Header) fs.FS
 }


### PR DESCRIPTION
golint is archived in favour of revive

Signed-off-by: Dave Henderson <dhenderson@gmail.com>