### PR TITLE
Add AWS Secrets Manager FS

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Here's the list of planned filesystem support, along with status:
 
 | Scheme(s) | Description | Supported? |
 |-----------|-------------|:----------:|
-| [`aws+sm`](./url_schemes.md#awssm) | [AWS Secrets Manager][] | |
+| [`aws+sm`](./url_schemes.md#awssm) | [AWS Secrets Manager][] | ✅ |
 | [`aws+smp`](./url_schemes.md#awssmp) | [AWS Systems Manager Parameter Store][AWS SMP] | |
 | [`azblob`](./url_schemes.md#azblob) | [Azure Blob Storage][] | ✅ |
 | [`consul`, `consul+http`, `consul+https`](./url_schemes.md#consul) | [HashiCorp Consul][] | |

--- a/autofs/lookup.go
+++ b/autofs/lookup.go
@@ -9,6 +9,7 @@ import (
 	"sync"
 
 	"github.com/hairyhenderson/go-fsimpl"
+	"github.com/hairyhenderson/go-fsimpl/awssmfs"
 	"github.com/hairyhenderson/go-fsimpl/blobfs"
 	"github.com/hairyhenderson/go-fsimpl/filefs"
 	"github.com/hairyhenderson/go-fsimpl/gitfs"
@@ -33,6 +34,7 @@ func Lookup(u string) (fs.FS, error) {
 		mux.Add(blobfs.FS)
 		mux.Add(gitfs.FS)
 		mux.Add(vaultfs.FS)
+		mux.Add(awssmfs.FS)
 	})
 
 	return mux.Lookup(u)

--- a/awssmfs/awssm.go
+++ b/awssmfs/awssm.go
@@ -1,0 +1,509 @@
+package awssmfs
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"io/fs"
+	"net/http"
+	"net/url"
+	"path"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/service/secretsmanager"
+	smtypes "github.com/aws/aws-sdk-go-v2/service/secretsmanager/types"
+	"github.com/hairyhenderson/go-fsimpl"
+	"github.com/hairyhenderson/go-fsimpl/internal"
+)
+
+// withSMClienter is an fs.FS that can be configured to use the given Secrets
+// Manager client.
+type withSMClienter interface {
+	WithSMClient(smclient SecretsManagerClient) fs.FS
+}
+
+// WithSMClientFS overrides the AWS Secrets Manager client used by fs, if the
+// filesystem supports it (i.e. has a WithSMClient method). This can be used for
+// configuring specialized client options.
+//
+// Note that this should not be used together with WithHTTPClient. If you wish
+// only to override the HTTP client, use WithHTTPClient alone.
+func WithSMClientFS(smclient SecretsManagerClient, fsys fs.FS) fs.FS {
+	if fsys, ok := fsys.(withSMClienter); ok {
+		return fsys.WithSMClient(smclient)
+	}
+
+	return fsys
+}
+
+type awssmFS struct {
+	ctx        context.Context
+	base       *url.URL
+	httpclient *http.Client
+	smclient   SecretsManagerClient
+	root       string
+}
+
+// New provides a filesystem (an fs.FS) backed by the AWS Secrets Manager,
+// rooted at the given URL. Note that the URL may be either a regular
+// hierarchical URL (like "aws+sm:///foo/bar") or an opaque URI (like
+// "aws+sm:foo/bar"), depending on how secrets are organized in Secrets Manager.
+//
+// A context can be given by using WithContextFS.
+func New(u *url.URL) (fs.FS, error) {
+	if u.Scheme != "aws+sm" {
+		return nil, fmt.Errorf("invalid URL scheme %q", u.Scheme)
+	}
+
+	root := u.Path
+	if root == "" {
+		root = u.Opaque
+	}
+
+	return &awssmFS{
+		ctx:  context.Background(),
+		base: u,
+		root: root,
+	}, nil
+}
+
+// FS is used to register this filesystem with an fsimpl.FSMux
+//
+//nolint:gochecknoglobals
+var FS = fsimpl.FSProviderFunc(New, "aws+sm")
+
+var (
+	_ fs.FS                     = (*awssmFS)(nil)
+	_ fs.ReadFileFS             = (*awssmFS)(nil)
+	_ fs.ReadDirFS              = (*awssmFS)(nil)
+	_ fs.SubFS                  = (*awssmFS)(nil)
+	_ internal.WithContexter    = (*awssmFS)(nil)
+	_ internal.WithHTTPClienter = (*awssmFS)(nil)
+	_ withSMClienter            = (*awssmFS)(nil)
+)
+
+func (f awssmFS) WithContext(ctx context.Context) fs.FS {
+	fsys := f
+	fsys.ctx = ctx
+
+	return &fsys
+}
+
+func (f awssmFS) WithHTTPClient(client *http.Client) fs.FS {
+	fsys := f
+	fsys.httpclient = client
+
+	return &fsys
+}
+
+func (f awssmFS) WithSMClient(smclient SecretsManagerClient) fs.FS {
+	fsys := f
+	fsys.smclient = smclient
+
+	return &fsys
+}
+
+func (f *awssmFS) getClient(ctx context.Context) (SecretsManagerClient, error) {
+	if f.smclient != nil {
+		return f.smclient, nil
+	}
+
+	opts := [](func(*config.LoadOptions) error){}
+	if f.httpclient != nil {
+		opts = append(opts, config.WithHTTPClient(f.httpclient))
+	}
+
+	cfg, err := config.LoadDefaultConfig(ctx, opts...)
+	if err != nil {
+		return nil, err
+	}
+
+	f.smclient = secretsmanager.NewFromConfig(cfg)
+
+	return f.smclient, nil
+}
+
+func (f *awssmFS) Sub(name string) (fs.FS, error) {
+	if !internal.ValidPath(name) {
+		return nil, &fs.PathError{Op: "sub", Path: name, Err: fs.ErrInvalid}
+	}
+
+	if name == "." || name == "" {
+		return f, nil
+	}
+
+	fsys := *f
+	fsys.root = path.Join(fsys.root, name)
+
+	return &fsys, nil
+}
+
+func (f *awssmFS) Open(name string) (fs.File, error) {
+	if !internal.ValidPath(name) {
+		return nil, &fs.PathError{Op: "open", Path: name, Err: fs.ErrInvalid}
+	}
+
+	smclient, err := f.getClient(f.ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	file := &awssmFile{
+		ctx:    f.ctx,
+		name:   strings.TrimPrefix(path.Base(name), "."),
+		root:   strings.TrimPrefix(path.Join(f.root, path.Dir(name)), "."),
+		client: smclient,
+	}
+
+	if name == "." {
+		file.fi = internal.DirInfo(file.name, time.Time{})
+
+		return file, nil
+	}
+
+	return file, nil
+}
+
+func (f *awssmFS) ReadDir(name string) ([]fs.DirEntry, error) {
+	if !internal.ValidPath(name) {
+		return nil, &fs.PathError{Op: "readdir", Path: name, Err: fs.ErrInvalid}
+	}
+
+	smclient, err := f.getClient(f.ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	dir := &awssmFile{
+		ctx:    f.ctx,
+		name:   name,
+		root:   f.root,
+		client: smclient,
+		fi:     internal.DirInfo(name, time.Time{}),
+	}
+
+	des, err := dir.ReadDir(-1)
+	if err != nil {
+		return nil, &fs.PathError{Op: "readDir", Path: name, Err: err}
+	}
+
+	return des, nil
+}
+
+// ReadFile implements fs.ReadFileFS.
+//
+// This implementation is slightly more performant than calling Open and then
+// reading the resulting fs.File.
+func (f *awssmFS) ReadFile(name string) ([]byte, error) {
+	if !internal.ValidPath(name) {
+		return nil, &fs.PathError{Op: "readFile", Path: name, Err: fs.ErrInvalid}
+	}
+
+	smclient, err := f.getClient(f.ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	secret, err := smclient.GetSecretValue(f.ctx, &secretsmanager.GetSecretValueInput{
+		SecretId: aws.String(path.Join(f.root, name)),
+	})
+	if err != nil {
+		return nil, &fs.PathError{Op: "readFile", Path: name, Err: convertAWSError(err)}
+	}
+
+	if secret.SecretString != nil {
+		return []byte(*secret.SecretString), nil
+	}
+
+	return secret.SecretBinary, nil
+}
+
+type awssmFile struct {
+	ctx    context.Context
+	fi     fs.FileInfo
+	client SecretsManagerClient
+	body   io.Reader
+	name   string
+	root   string
+
+	children []*awssmFile
+	diroff   int
+}
+
+var _ fs.ReadDirFile = (*awssmFile)(nil)
+
+func (f *awssmFile) Close() error {
+	// no-op - no state is kept
+	return nil
+}
+
+func (f *awssmFile) Read(p []byte) (int, error) {
+	if f.body == nil {
+		err := f.getSecret()
+		if err != nil {
+			return 0, &fs.PathError{Op: "read", Path: f.name, Err: err}
+		}
+	}
+
+	return f.body.Read(p)
+}
+
+func (f *awssmFile) Stat() (fs.FileInfo, error) {
+	if f.fi != nil {
+		return f.fi, nil
+	}
+
+	err := f.getSecret()
+	if err == nil {
+		return f.fi, nil
+	}
+
+	if !errors.Is(err, fs.ErrNotExist) {
+		return nil, &fs.PathError{Op: "stat", Path: f.name, Err: err}
+	}
+
+	// may be a directory, so attempt to list one child
+	// no need for special handling for opaque paths, as "." will never hit this
+	// code path (Open sets f.fi to a DirInfo)
+	filters := []smtypes.Filter{{Key: "name", Values: []string{path.Join(f.root, f.name) + "/"}}}
+	params := secretsmanager.ListSecretsInput{MaxResults: 1, Filters: filters}
+
+	secrets, err := f.client.ListSecrets(f.ctx, &params)
+	if err != nil {
+		return nil, &fs.PathError{Op: "stat", Path: f.name, Err: convertAWSError(err)}
+	}
+
+	if len(secrets.SecretList) == 0 {
+		return nil, &fs.PathError{Op: "stat", Path: f.name, Err: fs.ErrNotExist}
+	}
+
+	f.fi = internal.DirInfo(f.name, time.Time{})
+
+	return f.fi, nil
+}
+
+// convertAWSError converts an AWS error to an error suitable for returning
+// from the package. We don't want to leak SDK error types.
+func convertAWSError(err error) error {
+	// We can't find the resource that you asked for.
+	var rnfErr *smtypes.ResourceNotFoundException
+	if errors.As(err, &rnfErr) {
+		return fmt.Errorf("%w: %s", fs.ErrNotExist, rnfErr.ErrorMessage())
+	}
+
+	// Secrets Manager can't decrypt the protected secret text using the provided KMS key.
+	var dcErr *smtypes.DecryptionFailure
+	if errors.As(err, &dcErr) {
+		return fmt.Errorf("%w: %s: %s", fs.ErrPermission, dcErr.ErrorCode(), dcErr.ErrorMessage())
+	}
+
+	// An error occurred on the server side.
+	var internalErr *smtypes.InternalServiceError
+	if errors.As(err, &internalErr) {
+		return fmt.Errorf("internal error: %s: %s", internalErr.ErrorCode(), internalErr.ErrorMessage())
+	}
+
+	// You provided an invalid value for a parameter.
+	var paramErr *smtypes.InvalidParameterException
+	if errors.As(err, &paramErr) {
+		return fmt.Errorf("%w: %s", fs.ErrInvalid, paramErr.ErrorMessage())
+	}
+
+	// You provided a parameter value that is not valid for the current state of the resource.
+	var reqErr *smtypes.InvalidRequestException
+	if errors.As(err, &reqErr) {
+		return fmt.Errorf("%w: %s", fs.ErrInvalid, reqErr.ErrorMessage())
+	}
+
+	return err
+}
+
+// getSecret gets the secret value from AWS Secrets Manager and populates body
+// and fi. SDK errors will not be leaked, instead they will be converted to more
+// general errors.
+func (f *awssmFile) getSecret() error {
+	fullPath := path.Join(f.root, f.name)
+
+	secret, err := f.client.GetSecretValue(f.ctx, &secretsmanager.GetSecretValueInput{
+		SecretId: &fullPath,
+	})
+	if err != nil {
+		return fmt.Errorf("getSecretValue: %w", convertAWSError(err))
+	}
+
+	body := secret.SecretBinary
+
+	// May be a string
+	if secret.SecretString != nil {
+		body = []byte(*secret.SecretString)
+	}
+
+	seclen := int64(len(body))
+	f.body = bytes.NewReader(body)
+
+	// secret versions are immutable, so the created date for this version
+	// is also the last modified date
+	modTime := secret.CreatedDate
+	if modTime == nil {
+		modTime = &time.Time{}
+	}
+
+	// populate fi
+	f.fi = internal.FileInfo(f.name, seclen, 0o644, *modTime, "")
+
+	return nil
+}
+
+// listPrefix returns the secret prefix for this directory
+func (f *awssmFile) listPrefix() string {
+	// when listing "." at the root (or opaque root), avoid returning "//"
+	if f.name == "." && (f.root == "" || f.root == "/") {
+		return f.root
+	}
+
+	return path.Join(f.root, f.name) + "/"
+}
+
+func (f *awssmFile) listSecrets() ([]smtypes.SecretListEntry, error) {
+	prefix := f.listPrefix()
+
+	filter := prefix
+	if filter == "" {
+		// the opaque root (aws+sm:) is a special case - we need to list
+		// everything that doesn't start with /
+		filter = "!/"
+	}
+
+	secretList := []smtypes.SecretListEntry{}
+
+	for token := (*string)(nil); ; {
+		params := secretsmanager.ListSecretsInput{
+			Filters:   []smtypes.Filter{{Key: "name", Values: []string{filter}}},
+			NextToken: token,
+		}
+
+		secrets, err := f.client.ListSecrets(f.ctx, &params)
+		if err != nil {
+			return nil, fmt.Errorf("listSecrets: %w", err)
+		}
+
+		// trim the prefix from the names so we can use them as filenames
+		for _, secret := range secrets.SecretList {
+			name := strings.TrimPrefix(*secret.Name, prefix)
+			if prefix != "/" {
+				name = strings.TrimPrefix(name, "/")
+			}
+
+			*secret.Name = name
+		}
+
+		secretList = append(secretList, secrets.SecretList...)
+
+		token = secrets.NextToken
+		if token == nil {
+			break
+		}
+	}
+
+	// no such thing as empty directories in SM, they're artificial
+	if len(secretList) == 0 {
+		return nil, fmt.Errorf("%w (or empty): %q", fs.ErrNotExist, prefix)
+	}
+
+	return secretList, nil
+}
+
+// list assignes a sorted list of the children of this directory to f.children
+func (f *awssmFile) list() error {
+	secretList, err := f.listSecrets()
+	if err != nil {
+		return err
+	}
+
+	// a set of files that we've already seen - we don't want to add duplicates
+	seen := map[string]struct{}{}
+
+	for _, entry := range secretList {
+		parts := strings.SplitN(*entry.Name, "/", 2)
+		name := parts[0]
+
+		if _, ok := seen[name]; ok {
+			continue
+		}
+
+		seen[name] = struct{}{}
+
+		child := awssmFile{
+			ctx:    f.ctx,
+			name:   name,
+			root:   path.Join(f.root, f.name),
+			client: f.client,
+		}
+
+		if len(parts) > 1 {
+			// given that directories are artificial, they have a zero time
+			child.fi = internal.DirInfo(name, time.Time{})
+		} else {
+			fi, err := child.Stat()
+			if err != nil {
+				return err
+			}
+
+			child.fi = fi
+		}
+
+		f.children = append(f.children, &child)
+	}
+
+	// the AWS SDK doesn't sort the list of children, so we do it here
+	sort.Slice(f.children, func(i, j int) bool {
+		return f.children[i].name < f.children[j].name
+	})
+
+	return nil
+}
+
+// If n > 0, ReadDir returns at most n DirEntry structures.
+// In this case, if ReadDir returns an empty slice, it will return
+// a non-nil error explaining why.
+// At the end of a directory, the error is io.EOF.
+//
+// If n <= 0, ReadDir returns all the DirEntry values from the directory
+// in a single slice. In this case, if ReadDir succeeds (reads all the way
+// to the end of the directory), it returns the slice and a nil error.
+// If it encounters an error before the end of the directory,
+// ReadDir returns the DirEntry list read until that point and a non-nil error.
+func (f *awssmFile) ReadDir(n int) ([]fs.DirEntry, error) {
+	if f.children == nil {
+		if err := f.list(); err != nil {
+			return nil, fmt.Errorf("list: %w", err)
+		}
+	}
+
+	if n > 0 && f.diroff >= len(f.children) {
+		return nil, io.EOF
+	}
+
+	low := f.diroff
+	high := f.diroff + n
+
+	// clamp high at the max, and ensure it's higher than low
+	if high >= len(f.children) || high <= low {
+		high = len(f.children)
+	}
+
+	entries := make([]fs.DirEntry, high-low)
+	for i := low; i < high; i++ {
+		entries[i-low] = internal.FileInfoDirEntry(f.children[i].fi)
+	}
+
+	f.diroff = high
+
+	return entries, nil
+}

--- a/awssmfs/awssm_test.go
+++ b/awssmfs/awssm_test.go
@@ -1,0 +1,286 @@
+package awssmfs
+
+import (
+	"io"
+	"io/fs"
+	"testing"
+	"testing/fstest"
+
+	smtypes "github.com/aws/aws-sdk-go-v2/service/secretsmanager/types"
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/hairyhenderson/go-fsimpl/internal/tests"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func setupAWSSMFsys(t *testing.T, dir string) fs.FS {
+	fsys, err := New(tests.MustURL("aws+sm:///" + dir))
+	assert.NoError(t, err)
+
+	fsys = WithSMClientFS(clientWithValues(t, map[string]*testVal{
+		"noleadingslash":  vs("shouldn't be read"),
+		"noleading/slash": vs("shouldn't be read"),
+		"/notsub/bogus":   vs("not part of /sub"),
+		"/sub/a/aa":       vs("aaa"),
+		"/sub/a/ab":       vs("aab"),
+		"/sub/a/ac":       vs("aac"),
+		"/sub/b/ba/baa":   vb([]byte("bbabaa")),
+		"/sub/b/ba/bab":   vb([]byte("bbabab")),
+		"/sub/b/bb/bba":   vb([]byte("bbbbba")),
+		"/sub/b/bb/bbb":   vb([]byte("bbbbbb")),
+		"/sub/b/bb/bbc":   vb([]byte("bbbbbc")),
+		"/sub/b/bc/bca":   vb([]byte{0xde, 0xad, 0xbe, 0xef}),
+		"/sub/blah":       vb([]byte("blah")),
+		"/sub/c/ca/caa":   vs("ccacaa"),
+		"/sub/c/cb":       vs("ccb"),
+	}), fsys)
+
+	return fsys
+}
+
+func setupOpaqueAWSSMFsys(t *testing.T, prefix string) fs.FS {
+	fsys, err := New(tests.MustURL("aws+sm:" + prefix))
+	assert.NoError(t, err)
+
+	fsys = WithSMClientFS(clientWithValues(t, map[string]*testVal{
+		"/notlisted/bogus": vs("not listed because of the / prefix"),
+		"/nope":            vs("not listed because of the / prefix"),
+		"blah":             vb([]byte("blah")),
+		"a/aa":             vs("aaa"),
+		"b/ba/baa":         vb([]byte("bbabaa")),
+		"b/ba/bab":         vb([]byte("bbabab")),
+		"b/bb/bba":         vb([]byte("bbbbba")),
+		"b/bb/bbb":         vb([]byte("bbbbbb")),
+		"b/bb/bbc":         vb([]byte("bbbbbc")),
+		"b/bc/bca":         vb([]byte{0xde, 0xad, 0xbe, 0xef}),
+		"c/cb":             vs("ccb"),
+	}), fsys)
+
+	return fsys
+}
+
+func TestAWSSMFS_TestFS(t *testing.T) {
+	fsys := setupAWSSMFsys(t, "sub")
+
+	assert.NoError(t, fstest.TestFS(fsys,
+		"a", "b", "c",
+		"b/ba", "b/bb", "b/bc", "c/ca",
+		"a/aa", "a/ab", "a/ac",
+		"b/ba/baa", "b/ba/bab",
+		"b/bb/bba", "b/bb/bbb", "b/bb/bbc",
+		"b/bc/bca",
+		"c/ca/caa",
+		"c/cb",
+	))
+
+	// test opaque
+	fsys = setupOpaqueAWSSMFsys(t, "b")
+	assert.NoError(t, fstest.TestFS(fsys,
+		"ba", "bb", "bc",
+		"ba/baa", "ba/bab",
+		"bb/bba", "bb/bbb", "bb/bbc",
+		"bc/bca"))
+}
+
+func TestAWSSMFS_New(t *testing.T) {
+	_, err := New(tests.MustURL("https://example.com"))
+	assert.Error(t, err)
+}
+
+func TestAWSSMFS_Stat(t *testing.T) {
+	fsys := setupAWSSMFsys(t, "sub")
+
+	f, err := fsys.Open(".")
+	assert.NoError(t, err)
+
+	fi, err := f.Stat()
+	assert.NoError(t, err)
+	assert.True(t, fi.IsDir())
+	assert.Equal(t, "", fi.Name())
+
+	f, err = fsys.Open("missing")
+	assert.NoError(t, err)
+
+	_, err = f.Stat()
+	assert.ErrorIs(t, err, fs.ErrNotExist)
+
+	_, err = fs.Stat(fsys, "noleadingslash")
+	assert.ErrorIs(t, err, fs.ErrNotExist)
+
+	fi, err = fs.Stat(fsys, "a")
+	assert.NoError(t, err)
+	assert.True(t, fi.IsDir())
+
+	fsys = setupOpaqueAWSSMFsys(t, "")
+
+	f, err = fsys.Open(".")
+	assert.NoError(t, err)
+
+	fi, err = f.Stat()
+	assert.NoError(t, err)
+	assert.True(t, fi.IsDir())
+
+	fsys = setupOpaqueAWSSMFsys(t, "b")
+
+	// make sure the file "blah" isn't misinterpreted as "b/lah"
+	_, err = fs.Stat(fsys, "lah")
+	assert.ErrorIs(t, err, fs.ErrNotExist)
+
+	// stat shouldn't leak AWS error types when ListSecrets errors
+	fsys, err = New(tests.MustURL("aws+sm:///"))
+	assert.NoError(t, err)
+
+	fsys = WithSMClientFS(clientWithValues(t,
+		map[string]*testVal{}, nil,
+		&smtypes.DecryptionFailure{},
+	), fsys)
+
+	_, err = fs.Stat(fsys, "blah")
+	assert.ErrorIs(t, err, fs.ErrPermission)
+
+	// shouldn't leak AWS error types when GetSecretValue errors
+	fsys = WithSMClientFS(clientWithValues(t,
+		map[string]*testVal{},
+		&smtypes.InvalidParameterException{},
+	), fsys)
+
+	_, err = fs.Stat(fsys, "blah")
+	assert.ErrorIs(t, err, fs.ErrInvalid)
+}
+
+func TestAWSSMFS_Read(t *testing.T) {
+	fsys := setupAWSSMFsys(t, "")
+
+	f, err := fsys.Open("sub/a/aa")
+	assert.NoError(t, err)
+
+	b, err := io.ReadAll(f)
+	assert.NoError(t, err)
+	assert.Equal(t, "aaa", string(b))
+
+	fsys, err = fs.Sub(fsys, "sub/b/bb")
+	assert.NoError(t, err)
+
+	f, err = fsys.Open("bbc")
+	assert.NoError(t, err)
+
+	defer f.Close()
+
+	b, err = io.ReadAll(f)
+	assert.NoError(t, err)
+	assert.Equal(t, "bbbbbc", string(b))
+
+	_, err = f.Read(b)
+	assert.Error(t, err)
+
+	// read shouldn't leak AWS error types when GetSecret errors
+	fsys, err = New(tests.MustURL("aws+sm:///"))
+	assert.NoError(t, err)
+
+	fsys = WithSMClientFS(clientWithValues(t,
+		map[string]*testVal{},
+		&smtypes.InternalServiceError{Message: aws.String("foo")},
+	), fsys)
+
+	_, err = fs.ReadFile(fsys, "blah")
+	assert.EqualError(t, err, "readFile blah: internal error: InternalServiceError: foo")
+}
+
+func TestAWSSMFS_ReadFile(t *testing.T) {
+	fsys := setupAWSSMFsys(t, "")
+
+	b, err := fs.ReadFile(fsys, "sub/a/aa")
+	assert.NoError(t, err)
+	assert.Equal(t, "aaa", string(b))
+
+	fsys, err = fs.Sub(fsys, "sub/a")
+	assert.NoError(t, err)
+
+	b, err = fs.ReadFile(fsys, "ab")
+	assert.NoError(t, err)
+	assert.Equal(t, "aab", string(b))
+}
+
+func TestAWSSMFS_ReadDir(t *testing.T) {
+	fsys, err := New(tests.MustURL("aws+sm:///"))
+	assert.NoError(t, err)
+
+	fsys = WithSMClientFS(clientWithValues(t, nil), fsys)
+
+	_, err = fs.ReadDir(fsys, "dir1")
+	assert.Error(t, err)
+	assert.ErrorIs(t, err, fs.ErrNotExist)
+
+	fsys = setupAWSSMFsys(t, "")
+
+	de, err := fs.ReadDir(fsys, ".")
+	assert.NoError(t, err)
+	assert.Len(t, de, 2)
+
+	for i, ex := range []string{"notsub", "sub"} {
+		assert.Equal(t, ex, de[i].Name())
+		assert.True(t, de[i].IsDir())
+	}
+
+	fsys = setupAWSSMFsys(t, "sub")
+
+	de, err = fs.ReadDir(fsys, ".")
+	assert.NoError(t, err)
+	assert.Len(t, de, 4)
+
+	testdata := []struct {
+		name string
+		dir  bool
+	}{
+		{"a", true}, {"b", true}, {"blah", false}, {"c", true},
+	}
+	for i, d := range testdata {
+		var fi fs.FileInfo
+		fi, err = de[i].Info()
+		assert.NoError(t, err)
+		assert.Equal(t, d.name, fi.Name())
+		assert.Equal(t, d.dir, fi.IsDir())
+	}
+
+	de, err = fs.ReadDir(fsys, "b")
+	assert.NoError(t, err)
+	assert.Len(t, de, 3)
+
+	f, err := fsys.Open("b/bb")
+	assert.NoError(t, err)
+	require.Implements(t, (*fs.ReadDirFile)(nil), f)
+
+	dir := f.(fs.ReadDirFile)
+
+	de, err = dir.ReadDir(-1)
+	assert.NoError(t, err)
+	assert.Len(t, de, 3)
+}
+
+func TestAWSSMFS_ReadDir_Opaque(t *testing.T) {
+	fsys := setupOpaqueAWSSMFsys(t, "")
+
+	de, err := fs.ReadDir(fsys, ".")
+	require.NoError(t, err)
+	require.Len(t, de, 4)
+
+	fi, err := de[0].Info()
+	assert.NoError(t, err)
+	assert.Equal(t, "a", fi.Name())
+	assert.True(t, fi.IsDir())
+
+	fi, err = de[1].Info()
+	assert.NoError(t, err)
+	assert.Equal(t, "b", fi.Name())
+	assert.True(t, fi.IsDir())
+
+	fi, err = de[2].Info()
+	assert.NoError(t, err)
+	assert.Equal(t, "blah", fi.Name())
+	assert.False(t, fi.IsDir())
+
+	fi, err = de[3].Info()
+	assert.NoError(t, err)
+	assert.Equal(t, "c", fi.Name())
+	assert.True(t, fi.IsDir())
+}

--- a/awssmfs/fake_client_test.go
+++ b/awssmfs/fake_client_test.go
@@ -1,0 +1,162 @@
+package awssmfs
+
+import (
+	"context"
+	"fmt"
+	"math/rand"
+	"sort"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/secretsmanager"
+	"github.com/aws/aws-sdk-go-v2/service/secretsmanager/types"
+)
+
+type fakeClient struct {
+	t       *testing.T
+	secrets map[string]*testVal
+	getErr  error
+	listErr error
+}
+
+var _ SecretsManagerClient = (*fakeClient)(nil)
+
+func (c *fakeClient) GetSecretValue(ctx context.Context, params *secretsmanager.GetSecretValueInput,
+	optFns ...func(*secretsmanager.Options)) (*secretsmanager.GetSecretValueOutput, error) {
+	c.t.Helper()
+
+	if c.getErr != nil {
+		return nil, c.getErr
+	}
+
+	name := *params.SecretId
+	if val, ok := c.secrets[name]; ok {
+		out := secretsmanager.GetSecretValueOutput{Name: aws.String(name)}
+
+		if val.b != nil {
+			out.SecretBinary = make([]byte, len(val.b))
+			copy(out.SecretBinary, val.b)
+		} else {
+			out.SecretString = aws.String(val.s)
+		}
+
+		return &out, nil
+	}
+
+	return nil, &types.ResourceNotFoundException{
+		Message: aws.String("Secrets Manager can't find the specified secret."),
+	}
+}
+
+//nolint:funlen,gocyclo
+func (c *fakeClient) ListSecrets(ctx context.Context, params *secretsmanager.ListSecretsInput,
+	optFns ...func(*secretsmanager.Options)) (out *secretsmanager.ListSecretsOutput, err error) {
+	c.t.Helper()
+
+	if c.listErr != nil {
+		return nil, c.listErr
+	}
+
+	nameFilter := ""
+
+	for _, f := range params.Filters {
+		if f.Key == "name" {
+			nameFilter = f.Values[0]
+
+			break
+		}
+	}
+
+	offset := 0
+	if params.NextToken != nil {
+		offset, err = strconv.Atoi(*params.NextToken)
+		if err != nil {
+			return nil, fmt.Errorf("invalid nextToken for fakeClient %q: %w", *params.NextToken, err)
+		}
+	}
+
+	secretList := []types.SecretListEntry{}
+
+	for k := range c.secrets {
+		cond := strings.HasPrefix(k, nameFilter)
+		if strings.HasPrefix(nameFilter, "!") {
+			cond = !strings.HasPrefix(k, nameFilter[1:])
+		}
+
+		if cond {
+			secretList = append(secretList, types.SecretListEntry{
+				Name: aws.String(k),
+			})
+		}
+	}
+
+	// sort so pagination works
+	sort.Slice(secretList, func(i, j int) bool {
+		return aws.ToString(secretList[i].Name) < aws.ToString(secretList[j].Name)
+	})
+
+	if params.MaxResults == 0 {
+		// default to 2 results so we trigger pagination
+		params.MaxResults = 2
+	}
+
+	l := len(secretList)
+	m := int(params.MaxResults)
+
+	high := offset + m
+
+	var nextToken *string
+
+	switch {
+	case high < l:
+		secretList = secretList[offset:high]
+		nextToken = aws.String(strconv.Itoa(high))
+	case offset < l:
+		secretList = secretList[offset:]
+	default:
+		secretList = nil
+	}
+
+	// un-sort for a slightly more realistic test
+	rand.Seed(time.Now().UnixNano())
+	rand.Shuffle(len(secretList), func(i, j int) {
+		secretList[i], secretList[j] = secretList[j], secretList[i]
+	})
+
+	return &secretsmanager.ListSecretsOutput{
+		SecretList: secretList,
+		NextToken:  nextToken,
+	}, nil
+}
+
+func clientWithValues(t *testing.T, secrets map[string]*testVal, errs ...error) *fakeClient {
+	t.Helper()
+
+	c := &fakeClient{t: t, secrets: secrets}
+
+	switch len(errs) {
+	case 1:
+		c.getErr = errs[0]
+	case 2:
+		c.getErr = errs[0]
+		c.listErr = errs[1]
+	}
+
+	return c
+}
+
+type testVal struct {
+	s string
+	b []byte
+}
+
+func vs(s string) *testVal {
+	return &testVal{s: s}
+}
+
+func vb(b []byte) *testVal {
+	return &testVal{b: b}
+}

--- a/awssmfs/types.go
+++ b/awssmfs/types.go
@@ -1,0 +1,16 @@
+package awssmfs
+
+import (
+	"context"
+
+	"github.com/aws/aws-sdk-go-v2/service/secretsmanager"
+)
+
+type SecretsManagerClient interface {
+	ListSecrets(ctx context.Context,
+		params *secretsmanager.ListSecretsInput,
+		optFns ...func(*secretsmanager.Options)) (*secretsmanager.ListSecretsOutput, error)
+	GetSecretValue(ctx context.Context,
+		params *secretsmanager.GetSecretValueInput,
+		optFns ...func(*secretsmanager.Options)) (*secretsmanager.GetSecretValueOutput, error)
+}

--- a/blobfs/blob.go
+++ b/blobfs/blob.go
@@ -461,8 +461,8 @@ func (f *blobFile) ReadDir(n int) ([]fs.DirEntry, error) {
 			obj.ModTime = *fakeModTime
 		}
 
-		dirent := internal.FileInfo(name, obj.Size, mode, obj.ModTime, "").(fs.DirEntry)
-		dirents = append(dirents, dirent)
+		fi := internal.FileInfo(name, obj.Size, mode, obj.ModTime, "")
+		dirents = append(dirents, internal.FileInfoDirEntry(fi))
 	}
 
 	return dirents, nil

--- a/extensions.go
+++ b/extensions.go
@@ -22,8 +22,8 @@ func WithContextFS(ctx context.Context, fsys fs.FS) fs.FS {
 	return fsys
 }
 
-// WithHeaderFS injects a context into the filesystem fs, if the filesystem
-// supports it (i.e. has a WithHeader method).
+// WithHeaderFS injects the given HTTP header into the filesystem fs, if the
+// filesystem supports it (i.e. has a WithHeader method).
 func WithHeaderFS(headers http.Header, fsys fs.FS) fs.FS {
 	if cfsys, ok := fsys.(internal.WithHeaderer); ok {
 		return cfsys.WithHeader(headers)

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,9 @@ go 1.17
 require (
 	github.com/Azure/azure-storage-blob-go v0.14.0
 	github.com/aws/aws-sdk-go v1.40.58
+	github.com/aws/aws-sdk-go-v2 v1.9.1
+	github.com/aws/aws-sdk-go-v2/config v1.8.2
+	github.com/aws/aws-sdk-go-v2/service/secretsmanager v1.6.0
 	github.com/fsouza/fake-gcs-server v1.30.1
 	github.com/go-git/go-billy/v5 v5.3.1
 	github.com/go-git/go-git/v5 v5.4.2
@@ -29,8 +32,6 @@ require (
 	github.com/Microsoft/go-winio v0.5.0 // indirect
 	github.com/ProtonMail/go-crypto v0.0.0-20210920160938-87db9fbc61c7 // indirect
 	github.com/acomagu/bufpipe v1.0.3 // indirect
-	github.com/aws/aws-sdk-go-v2 v1.9.1 // indirect
-	github.com/aws/aws-sdk-go-v2/config v1.8.2 // indirect
 	github.com/aws/aws-sdk-go-v2/credentials v1.4.2 // indirect
 	github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.5.1 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/ini v1.2.3 // indirect

--- a/go.sum
+++ b/go.sum
@@ -168,6 +168,7 @@ github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.3.0/go.mod h1:R1K
 github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.3.1 h1:APEjhKZLFlNVLATnA/TJyA+w1r/xd5r5ACWBDZ9aIvc=
 github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.3.1/go.mod h1:Ve+eJOx9UWaT/lMVebnFhDhO49fSLVedHoA82+Rqme0=
 github.com/aws/aws-sdk-go-v2/service/kms v1.5.0/go.mod h1:w7JuP9Oq1IKMFQPkNe3V6s9rOssXzOVEMNEqK1L1bao=
+github.com/aws/aws-sdk-go-v2/service/secretsmanager v1.6.0 h1:3vxYnnbPWwECs3xN+cu/bRefhynMOH6elQAxuHES01Q=
 github.com/aws/aws-sdk-go-v2/service/secretsmanager v1.6.0/go.mod h1:B+7C5UKdVq1ylkI/A6O8wcurFtaux0R1njePNPtKwoA=
 github.com/aws/aws-sdk-go-v2/service/ssm v1.10.0/go.mod h1:4dXS5YNqI3SNbetQ7X7vfsMlX6ZnboJA2dulBwJx7+g=
 github.com/aws/aws-sdk-go-v2/service/sso v1.4.0/go.mod h1:+1fpWnL96DL23aXPpMGbsmKe8jLTEfbjuQoA4WS1VaA=

--- a/internal/billyadapter/btofs.go
+++ b/internal/billyadapter/btofs.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"github.com/go-git/go-billy/v5"
+	"github.com/hairyhenderson/go-fsimpl/internal"
 )
 
 func BillyToFS(bfs billy.Filesystem) fs.ReadDirFS {
@@ -159,23 +160,8 @@ func dirents(children []fs.FileInfo) []fs.DirEntry {
 	entries := make([]fs.DirEntry, len(children))
 
 	for i, fi := range children {
-		switch de := fi.(type) {
-		case fs.DirEntry:
-			entries[i] = de
-		default:
-			entries[i] = &fileinfoDirEntry{fi}
-		}
+		entries[i] = internal.FileInfoDirEntry(fi)
 	}
 
 	return entries
 }
-
-// a wrapper to make a fs.FileInfo into an fs.DirEntry
-type fileinfoDirEntry struct {
-	fs.FileInfo
-}
-
-var _ fs.DirEntry = (*fileinfoDirEntry)(nil)
-
-func (fi *fileinfoDirEntry) Info() (fs.FileInfo, error) { return fi, nil }
-func (fi *fileinfoDirEntry) Type() fs.FileMode          { return fi.Mode().Type() }

--- a/internal/path.go
+++ b/internal/path.go
@@ -1,0 +1,14 @@
+package internal
+
+import (
+	"io/fs"
+	"strings"
+)
+
+func ValidPath(name string) bool {
+	if strings.Contains(name, "\\") {
+		return false
+	}
+
+	return fs.ValidPath(name)
+}

--- a/internal/types.go
+++ b/internal/types.go
@@ -52,6 +52,28 @@ func (fi staticFileInfo) Sys() interface{}            { return nil }
 func (fi *staticFileInfo) Info() (fs.FileInfo, error) { return fi, nil }
 func (fi staticFileInfo) Type() fs.FileMode           { return fi.Mode().Type() }
 
+// FileInfoDirEntry adapts a fs.FileInfo into a fs.DirEntry. If it doesn't
+// already implement fs.DirEntry, it will be wrapped to always return the
+// same fs.FileInfo.
+func FileInfoDirEntry(fi fs.FileInfo) fs.DirEntry {
+	de, ok := fi.(fs.DirEntry)
+	if ok {
+		return de
+	}
+
+	return &fileinfoDirEntry{fi}
+}
+
+// a wrapper to make a fs.FileInfo into an fs.DirEntry
+type fileinfoDirEntry struct {
+	fs.FileInfo
+}
+
+var _ fs.DirEntry = (*fileinfoDirEntry)(nil)
+
+func (fi *fileinfoDirEntry) Info() (fs.FileInfo, error) { return fi, nil }
+func (fi *fileinfoDirEntry) Type() fs.FileMode          { return fi.Mode().Type() }
+
 // ContentTypeFileInfo is an fs.FileInfo that can also report its content type
 type ContentTypeFileInfo interface {
 	fs.FileInfo

--- a/url_schemes.md
+++ b/url_schemes.md
@@ -29,6 +29,21 @@ particular purposes.
     `s3://my-bucket?region=us-west-1`.
 - _fragment:_ Used rarely
 
+### Opaque URIs
+
+For some filesystems, opaque URIs can be used (rather than a hierarchical URL):
+
+```pre
+scheme                   path        query   fragment
+   |   _____________________|__   _______|_   _|
+  / \ /                        \ /         \ /  \
+  urn:example:animal:ferret:nose?name=ferret#nose
+```
+
+The semantics of the different URI components are essentially the same as for
+hierarchical URLs (see above), but the _path_ component may not start with a `/`
+character.
+
 ### Non-standard URL conventions
 
 For the most part, this module uses standard URL conventions as much as
@@ -49,16 +64,24 @@ filesystem will be rooted at `/cmd/which` inside the `go-which` repo.
 
 ### `aws+sm`
 
-The _scheme_ and _path_ components are used by this filesystem.
+The _scheme_ and _path_ components are used by this filesystem. This may be an
+[_opaque_ URI](#opaque-uris) (rather than a hierarchical URL) when the secret
+name or prefix does not begin with a `/` character (e.g. `aws+sm:prod/env1`).
 
 - _scheme_ must be `aws+sm`
-- _path_ is used optionally to specify the root secret heirarchy
+- _path_ is used optionally to specify the root secret heirarchy (this may be a
+hierarchical path beginning with `/`, or an opaque path without a leading `/`)
 
 #### Examples
 
-- `aws+sm:///` - filesystem that makes all accessible secrets available
+- `aws+sm:///` - filesystem that makes all accessible secrets available which
+    are prefixed with a `/` character.
 - `aws+sm:///scoped/secrets` - filesystem that makes available only secrets
-    with a prefix of `/scoped/secrets`.
+    whose names begin with `/scoped/secrets/`.
+- `aws+sm:` - filesystem that makes available all accessible secrets which are
+    not prefixed with a `/` character.
+- `aws+sm:prod/env1` - filesystem that makes available only secrets whose names
+    begin with `prod/env1/`.
 
 ### `aws+smp`
 

--- a/vaultfs/vault.go
+++ b/vaultfs/vault.go
@@ -12,7 +12,6 @@ import (
 	"net/http"
 	"net/url"
 	"path"
-	"runtime"
 	"strings"
 	"sync/atomic"
 	"time"
@@ -140,16 +139,8 @@ func (f vaultFS) WithAuthMethod(auth AuthMethod) fs.FS {
 	return &fsys
 }
 
-func validPath(name string) bool {
-	if runtime.GOOS != "windows" && strings.Contains(name, "\\") {
-		return false
-	}
-
-	return fs.ValidPath(name)
-}
-
 func (f vaultFS) Open(name string) (fs.File, error) {
-	if !validPath(name) {
+	if !internal.ValidPath(name) {
 		return nil, &fs.PathError{Op: "open", Path: name, Err: fs.ErrInvalid}
 	}
 
@@ -169,7 +160,7 @@ func (f vaultFS) Open(name string) (fs.File, error) {
 //
 // This implementation minimises Vault token uses by avoiding an extra Stat.
 func (f vaultFS) ReadFile(name string) ([]byte, error) {
-	if !validPath(name) {
+	if !internal.ValidPath(name) {
 		return nil, &fs.PathError{Op: "readFile", Path: name, Err: fs.ErrInvalid}
 	}
 
@@ -454,10 +445,8 @@ func (f *vaultFile) ReadDir(n int) ([]fs.DirEntry, error) {
 
 		// vault lists directories with trailing slashes
 		if strings.HasSuffix(childName, "/") {
-			dirents = append(dirents, internal.DirInfo(
-				childName[:len(childName)-1],
-				time.Time{},
-			).(fs.DirEntry))
+			fi := internal.DirInfo(childName[:len(childName)-1], time.Time{})
+			dirents = append(dirents, internal.FileInfoDirEntry(fi))
 
 			continue
 		}
@@ -470,7 +459,7 @@ func (f *vaultFile) ReadDir(n int) ([]fs.DirEntry, error) {
 			return nil, &fs.PathError{Op: "readDir", Path: f.name, Err: err}
 		}
 
-		dirents = append(dirents, fi.(fs.DirEntry))
+		dirents = append(dirents, internal.FileInfoDirEntry(fi))
 	}
 
 	f.diridx += len(dirents)


### PR DESCRIPTION
Fixes #6 

Support for AWS SM filesystem, with the `aws+sm` URL scheme.

Because this is effectively a flat namespace, I had to infer directory structure (using `/` as path separator in the secret name, as seems to be the recommendation in the AWS docs). A side-effect is that you can either get a filesystem rooted on secrets that start with `/`, or not. That means if a SM store has two secrets `/foo` and `bar`, you can't have a filesystem where both will be accessible. I think in practice this may not be a big deal, as I expect Secrets Manager users will likely use either a `/`-rooted convention, or not, but not both.

Signed-off-by: Dave Henderson <dhenderson@gmail.com>