### PR TITLE
gitfs: support setting explicit auth methods

### DIFF
--- a/gitfs/auth.go
+++ b/gitfs/auth.go
@@ -1,0 +1,278 @@
+package gitfs
+
+import (
+	"encoding/base64"
+	"fmt"
+	"io/fs"
+	"net/url"
+	"os"
+
+	githttp "github.com/go-git/go-git/v5/plumbing/transport/http"
+	"github.com/go-git/go-git/v5/plumbing/transport/ssh"
+	"github.com/hairyhenderson/go-fsimpl/internal/env"
+)
+
+// withAuthenticatorer is an fs.FS that can be configured to authenticate to a
+// git repository using a specific method
+type withAuthenticatorer interface {
+	WithAuthenticator(auth Authenticator) fs.FS
+}
+
+// Authenticator provides an AuthMethod for a given URL. If the URL is not
+// appropriate for the given AuthMethod, an error will be returned.
+type Authenticator interface {
+	Authenticate(u *url.URL) (AuthMethod, error)
+}
+
+type authenticatorFunc func(u *url.URL) (AuthMethod, error)
+
+func (a authenticatorFunc) Authenticate(u *url.URL) (AuthMethod, error) {
+	return a(u)
+}
+
+// AuthMethod is an HTTP or SSH authentication method that can be used to
+// authenticate to a git repository.
+// See the github.com/go-git/go-git module for details.
+type AuthMethod interface {
+	fmt.Stringer
+	Name() string
+}
+
+// WithAuthenticator configures the given FS to authenticate with auth, if the
+// filesystem supports it.
+func WithAuthenticator(auth Authenticator, fsys fs.FS) fs.FS {
+	if afsys, ok := fsys.(withAuthenticatorer); ok {
+		return afsys.WithAuthenticator(auth)
+	}
+
+	return fsys
+}
+
+var (
+	_ Authenticator = (*authenticatorFunc)(nil)
+	_ Authenticator = (*basicAuthenticator)(nil)
+)
+
+// AutoAuthenticator is an Authenticator that chooses the first available
+// authenticator based on the given URL (when appropriate) and the environment
+// variables, in this order of precedence:
+//
+//	BasicAuthenticator
+//	TokenAuthenticator
+//	PublicKeyAuthenticator
+//	SSHAgentAuthenticator
+//	NoopAuthenticator
+func AutoAuthenticator() Authenticator {
+	return &autoAuthenticator{
+		authenticators: []Authenticator{
+			BasicAuthenticator("", ""),
+			TokenAuthenticator(""),
+			PublicKeyAuthenticator("", []byte{}, ""),
+			SSHAgentAuthenticator(""),
+			NoopAuthenticator(),
+		},
+	}
+}
+
+type autoAuthenticator struct {
+	authenticators []Authenticator
+}
+
+func (a *autoAuthenticator) Authenticate(u *url.URL) (AuthMethod, error) {
+	for _, auth := range a.authenticators {
+		if method, err := auth.Authenticate(u); err == nil {
+			return method, nil
+		}
+	}
+
+	return nil, fmt.Errorf("no authentication method available for %s", u)
+}
+
+// NoopAuthenticator is an Authenticator that will not attempt any
+// authentication methods. Can only be used with 'git', 'file', 'http', and
+// 'https' schemes.
+//
+// Useful when desiring no authentication at all (e.g. for local repositories,
+// or to ensure that target repositories are public).
+func NoopAuthenticator() Authenticator {
+	return authenticatorFunc(func(u *url.URL) (AuthMethod, error) {
+		if u.Scheme != "git" && u.Scheme != "file" && u.Scheme != "http" && u.Scheme != "https" {
+			return nil, fmt.Errorf("no-op authentication not supported for scheme %q", u.Scheme)
+		}
+
+		return nil, nil
+	})
+}
+
+// BasicAuthenticator is an Authenticator that provides HTTP Basic
+// Authentication. Use only with HTTP/HTTPS repositories.
+//
+// A username or password provided in the URL will override the credentials
+// provided here.
+// If password is omitted, the environment variable GIT_HTTP_PASSWORD will be
+// used.
+// If GIT_HTTP_PASSWORD_FILE is set, the password will be read from the
+// referenced file on the local filesystem.
+//
+// For authenticating with GitHub, Bitbucket, GitLab, and other popular git
+// hosts, use this with a personal access token, with username 'git'.
+func BasicAuthenticator(username, password string) Authenticator {
+	return &basicAuthenticator{
+		envfsys: os.DirFS("/"), username: username, password: password,
+	}
+}
+
+type basicAuthenticator struct {
+	envfsys            fs.FS
+	username, password string
+}
+
+func (a *basicAuthenticator) Authenticate(u *url.URL) (AuthMethod, error) {
+	if u.Scheme != "http" && u.Scheme != "https" {
+		return nil, fmt.Errorf("basic authentication not supported for scheme %q", u.Scheme)
+	}
+
+	username := u.User.Username()
+	if username == "" {
+		username = a.username
+	}
+
+	// password can come from URL, environment, or the provided one
+	password, _ := u.User.Password()
+	if password == "" {
+		password = a.password
+	}
+
+	if password == "" {
+		password = env.GetenvFS(a.envfsys, "GIT_HTTP_PASSWORD")
+	}
+
+	if username == "" && password == "" {
+		return nil, nil
+	}
+
+	return &githttp.BasicAuth{Username: username, Password: password}, nil
+}
+
+// TokenAuthenticator is an Authenticator that uses HTTP token authentication
+// (also known as bearer authentication).
+//
+// If token is omitted, the environment variable GIT_HTTP_TOKEN will be	used.
+// If GIT_HTTP_TOKEN_FILE is set, the token will be read from the referenced
+// file on the local filesystem.
+//
+// Note: If you are looking to use OAuth tokens with popular servers (e.g.
+// GitHub, Bitbucket, GitLab), use BasicAuthenticator instead. These servers
+// use HTTP Basic Authentication, with the OAuth token as user or password.
+func TokenAuthenticator(token string) Authenticator {
+	return &tokenAuthenticator{envfsys: os.DirFS("/"), token: token}
+}
+
+type tokenAuthenticator struct {
+	envfsys fs.FS
+	token   string
+}
+
+func (a *tokenAuthenticator) Authenticate(u *url.URL) (AuthMethod, error) {
+	if u.Scheme != "http" && u.Scheme != "https" {
+		return nil, fmt.Errorf("token authentication not supported for scheme %q", u.Scheme)
+	}
+
+	token := a.token
+	if token == "" {
+		token = env.GetenvFS(a.envfsys, "GIT_HTTP_TOKEN")
+	}
+
+	if token == "" {
+		return nil, fmt.Errorf("token may not be empty for token authentication")
+	}
+
+	return &githttp.TokenAuth{Token: token}, nil
+}
+
+// PublicKeyAuthenticator provides an an Authenticator that uses SSH public key
+// authentication. Use only with SSH repositories.
+//
+// The privkey is a PEM-encoded private key. Set keyPass if privKey is a
+// password-encrypted PEM block, otherwise leave it empty.
+//
+// If privKey is omitted, the GIT_SSH_KEY environment variable will be used. For
+// ease of use, the variable may optionally be base64-encoded. If
+// GIT_SSH_KEY_FILE is set, the key will be read from the referenced file on the
+// local filesystem.
+//
+// Supports PKCS#1 (RSA), PKCS#8 (RSA, ECDSA, ed25519), SEC 1 (ECDSA),
+// DSA (OpenSSL), and OpenSSH private keys.
+func PublicKeyAuthenticator(username string, privKey []byte, keyPass string) Authenticator {
+	return &publicKeyAuthenticator{
+		envfsys: os.DirFS("/"), username: username, privKey: privKey, keyPass: keyPass,
+	}
+}
+
+type publicKeyAuthenticator struct {
+	envfsys  fs.FS
+	username string
+	keyPass  string
+	privKey  []byte
+}
+
+func (a *publicKeyAuthenticator) Authenticate(u *url.URL) (AuthMethod, error) {
+	if u.Scheme != "ssh" {
+		return nil, fmt.Errorf("public key authentication not supported for scheme %q", u.Scheme)
+	}
+
+	username := u.User.Username()
+	if username == "" {
+		username = a.username
+	}
+
+	k := a.privKey
+	if len(k) == 0 {
+		var err error
+
+		envKey := env.GetenvFS(a.envfsys, "GIT_SSH_KEY")
+
+		k, err = base64.StdEncoding.DecodeString(envKey)
+		if err != nil {
+			// if it can't be base64-decoded, assume it was a non-base64 key
+			// from a file
+			k = []byte(envKey)
+		}
+	}
+
+	if len(k) == 0 {
+		return nil, fmt.Errorf("private key may not be empty for public key authentication")
+	}
+
+	return ssh.NewPublicKeys(username, k, a.keyPass)
+}
+
+// SSHAgentAuthenticator is an Authenticator that uses the ssh-agent protocol.
+// Use only with SSH repositories.
+//
+// If username is not provided or present in the URL, the user will be the same
+// as the current user.
+//
+// This method depends on the SSH_AUTH_SOCK environment variable being correctly
+// configured by the SSH agent. See ssh-agent(1) for details.
+func SSHAgentAuthenticator(username string) Authenticator {
+	return &sshAgentAuthenticator{envfsys: os.DirFS("/"), username: username}
+}
+
+type sshAgentAuthenticator struct {
+	envfsys  fs.FS
+	username string
+}
+
+func (a *sshAgentAuthenticator) Authenticate(u *url.URL) (AuthMethod, error) {
+	if u.Scheme != "ssh" {
+		return nil, fmt.Errorf("ssh-agent authentication not supported for scheme %q", u.Scheme)
+	}
+
+	username := u.User.Username()
+	if username == "" {
+		username = a.username
+	}
+
+	return ssh.NewSSHAgentAuth(username)
+}

--- a/gitfs/auth_test.go
+++ b/gitfs/auth_test.go
@@ -1,0 +1,339 @@
+package gitfs
+
+import (
+	"encoding/base64"
+	"fmt"
+	"io/fs"
+	"net/url"
+	"os"
+	"os/user"
+	"testing"
+	"testing/fstest"
+
+	githttp "github.com/go-git/go-git/v5/plumbing/transport/http"
+	"github.com/go-git/go-git/v5/plumbing/transport/ssh"
+	"github.com/hairyhenderson/go-fsimpl/internal/tests"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/crypto/ssh/testdata"
+)
+
+func TestAutoAuthenticator(t *testing.T) {
+	a := AutoAuthenticator()
+
+	_, err := a.Authenticate(tests.MustURL("bogus:///bare.git"))
+	assert.Error(t, err)
+
+	// valid for all supported schemes
+	am, err := a.Authenticate(tests.MustURL("git://"))
+	assert.NoError(t, err)
+	// no-op returns a nil AuthMethod
+	assert.Nil(t, am)
+
+	am, err = a.Authenticate(tests.MustURL("file:///bare.git"))
+	assert.NoError(t, err)
+	// no-op returns a nil AuthMethod
+	assert.Nil(t, am)
+
+	// basic auth
+	am, err = a.Authenticate(tests.MustURL("https://user@example.com"))
+	assert.NoError(t, err)
+	assert.EqualValues(t,
+		&githttp.BasicAuth{Username: "user", Password: ""}, am)
+
+	t.Run("with ssh-agent", func(t *testing.T) {
+		if os.Getenv("SSH_AUTH_SOCK") == "" {
+			t.Skip("SSH_AUTH_SOCK not set")
+		}
+
+		// ssh-agent auth
+		am, err = a.Authenticate(tests.MustURL("ssh://git@example.com"))
+		assert.NoError(t, err)
+
+		pkc, ok := am.(*ssh.PublicKeysCallback)
+		assert.True(t, ok)
+		assert.Equal(t, "git", pkc.User)
+	})
+
+	// ssh public key auth with env var
+	key := base64.StdEncoding.EncodeToString(testdata.PEMBytes["rsa"])
+
+	os.Setenv("GIT_SSH_KEY", key)
+	defer os.Unsetenv("GIT_SSH_KEY")
+
+	am, err = a.Authenticate(tests.MustURL("ssh://git@example.com"))
+	assert.NoError(t, err)
+
+	pk, ok := am.(*ssh.PublicKeys)
+	assert.True(t, ok)
+	assert.Equal(t, "git", pk.User)
+}
+
+func ExampleAutoAuthenticator() {
+	u, _ := url.Parse("https://github.com/git-fixtures/basic//json/")
+
+	fsys, _ := New(u)
+
+	// AutoAuthenticator is the default, so this is redundant, but left here for
+	// documentation purposes.
+	fsys = WithAuthenticator(AutoAuthenticator(), fsys)
+
+	// this will use authenticated access if set in the environment, or default
+	// to unauthenticated access.
+	fi, _ := fs.Stat(fsys, "short.json")
+	fmt.Printf("file size: %d\n", fi.Size())
+}
+
+func TestNoopAuthenticator(t *testing.T) {
+	a := NoopAuthenticator()
+
+	// only valid for git/file/http/https schemes
+	_, err := a.Authenticate(tests.MustURL("ssh://example.com/foo"))
+	assert.Error(t, err)
+
+	am, err := a.Authenticate(tests.MustURL("git://"))
+	assert.NoError(t, err)
+	assert.Nil(t, am)
+
+	am, err = a.Authenticate(tests.MustURL("file:///bare.git"))
+	assert.NoError(t, err)
+	assert.Nil(t, am)
+
+	am, err = a.Authenticate(tests.MustURL("https://example.com"))
+	assert.NoError(t, err)
+	assert.Nil(t, am)
+
+	am, err = a.Authenticate(tests.MustURL("http://example.com"))
+	assert.NoError(t, err)
+	assert.Nil(t, am)
+}
+
+func TestBasicAuthenticator(t *testing.T) {
+	envfsys := fstest.MapFS{}
+	a := &basicAuthenticator{envfsys: envfsys}
+
+	os.Unsetenv("GIT_HTTP_PASSWORD")
+
+	// only valid for http[s] schemes
+	_, err := a.Authenticate(tests.MustURL("file:///bare.git"))
+	assert.Error(t, err)
+
+	// user/pass are not required with basic auth - this results in a no-op -
+	// useful for public repos
+	am, err := a.Authenticate(tests.MustURL("http://example.com/foo"))
+	assert.NoError(t, err)
+	assert.Nil(t, am)
+
+	// credentials from URL
+	am, err = a.Authenticate(tests.MustURL("https://user:swordfish@example.com/foo"))
+	assert.NoError(t, err)
+	assert.EqualValues(t,
+		&githttp.BasicAuth{Username: "user", Password: "swordfish"}, am)
+
+	// credentials from env used when none are provided
+	os.Setenv("GIT_HTTP_PASSWORD", "swordfish")
+	defer os.Unsetenv("GIT_HTTP_PASSWORD")
+
+	am, err = a.Authenticate(tests.MustURL("https://example.com/foo"))
+	assert.NoError(t, err)
+	assert.EqualValues(t,
+		&githttp.BasicAuth{Username: "", Password: "swordfish"}, am)
+
+	// provided credentials override env used when none are provided
+	os.Setenv("GIT_HTTP_PASSWORD", "pufferfish")
+	defer os.Unsetenv("GIT_HTTP_PASSWORD")
+
+	a.username = "user"
+	a.password = "swordfish"
+	am, err = a.Authenticate(tests.MustURL("http://example.com/foo"))
+	assert.NoError(t, err)
+	assert.EqualValues(t,
+		&githttp.BasicAuth{Username: "user", Password: "swordfish"}, am)
+
+	// credentials from URL override provided & env credentials
+	am, err = a.Authenticate(tests.MustURL("https://foo:bar@example.com/foo"))
+	assert.NoError(t, err)
+	assert.EqualValues(t,
+		&githttp.BasicAuth{Username: "foo", Password: "bar"}, am)
+}
+
+// Using Basic Auth:
+func ExampleBasicAuthenticator() {
+	u, _ := url.Parse("https://mysite.com/myrepo.git")
+
+	fsys, _ := New(u)
+	fsys = WithAuthenticator(BasicAuthenticator("me", "mypassword"), fsys)
+
+	// this will use authenticated access
+	fi, _ := fs.Stat(fsys, "short.json")
+	fmt.Printf("file size: %d\n", fi.Size())
+
+	// or we can set user/password in the URL:
+	u, _ = url.Parse("https://me:mypassword@mysite.com/myrepo.git")
+
+	fsys, _ = New(u)
+	// no need to provide user/pass to the authenticator, but if we did, the URL
+	// values would override.
+	fsys = WithAuthenticator(BasicAuthenticator("", ""), fsys)
+
+	fi, _ = fs.Stat(fsys, "short.json")
+	fmt.Printf("file size: %d\n", fi.Size())
+}
+
+// Using Basic Auth with a public (unauthenticated) repo:
+func ExampleBasicAuthenticator_unauthenticated() {
+	u, _ := url.Parse("https://github.com/git-fixtures/basic//json/")
+
+	fsys, _ := New(u)
+
+	// Use BasicAuthenticator with no user/pass to get unauthenticated access.
+	// See also NoopAuthenticator to prevent authentication from URL.
+	fsys = WithAuthenticator(BasicAuthenticator("", ""), fsys)
+
+	fi, _ := fs.Stat(fsys, "short.json")
+	fmt.Printf("file size: %d\n", fi.Size())
+}
+
+func TestTokenAuthenticator(t *testing.T) {
+	envfsys := fstest.MapFS{}
+	a := &tokenAuthenticator{envfsys: envfsys}
+
+	os.Unsetenv("GIT_HTTP_TOKEN")
+
+	// only valid for http[s] schemes
+	_, err := a.Authenticate(tests.MustURL("file:///bare.git"))
+	assert.Error(t, err)
+
+	// token must be set _somewhere_
+	_, err = a.Authenticate(tests.MustURL("https://example.com/foo"))
+	assert.Error(t, err)
+
+	// token from env
+	os.Setenv("GIT_HTTP_TOKEN", "foo")
+	defer os.Unsetenv("GIT_HTTP_TOKEN")
+
+	am, err := a.Authenticate(tests.MustURL("http://example.com/foo"))
+	assert.NoError(t, err)
+	assert.EqualValues(t, &githttp.TokenAuth{Token: "foo"}, am)
+
+	// provided token overrides env
+	a.token = "bar"
+	am, err = a.Authenticate(tests.MustURL("https://example.com/foo"))
+	assert.NoError(t, err)
+	assert.EqualValues(t, &githttp.TokenAuth{Token: "bar"}, am)
+}
+
+//nolint:funlen
+func TestPublicKeyAuthenticator(t *testing.T) {
+	envfsys := fstest.MapFS{}
+	a := &publicKeyAuthenticator{envfsys: envfsys}
+
+	os.Unsetenv("GIT_SSH_KEY")
+
+	// only valid for ssh schemes
+	_, err := a.Authenticate(tests.MustURL("file:///bare.git"))
+	assert.Error(t, err)
+
+	_, err = a.Authenticate(tests.MustURL("https:///bare.git"))
+	assert.Error(t, err)
+
+	// key must be set _somewhere_
+	_, err = a.Authenticate(tests.MustURL("ssh://example.com/foo"))
+	assert.Error(t, err)
+
+	// key from env, base64-encoded
+	key := string(testdata.PEMBytes["ed25519"])
+
+	enckey := base64.StdEncoding.EncodeToString([]byte(key))
+
+	os.Setenv("GIT_SSH_KEY", enckey)
+	defer os.Unsetenv("GIT_SSH_KEY")
+
+	am, err := a.Authenticate(tests.MustURL("ssh://example.com/foo"))
+	assert.NoError(t, err)
+	assert.IsType(t, &ssh.PublicKeys{}, am)
+
+	// key from file referenced by env (non-base64)
+	os.Unsetenv("GIT_SSH_KEY")
+
+	os.Setenv("GIT_SSH_KEY_FILE", "/testdata/key.pem")
+	defer os.Unsetenv("GIT_SSH_KEY_FILE")
+
+	envfsys["testdata/key.pem"] = &fstest.MapFile{Data: []byte(key)}
+
+	am, err = a.Authenticate(tests.MustURL("ssh://example.com/foo"))
+	assert.NoError(t, err)
+	assert.IsType(t, &ssh.PublicKeys{}, am)
+
+	// provided key overrides env
+	os.Unsetenv("GIT_SSH_KEY_FILE")
+
+	os.Setenv("GIT_SSH_KEY", "unparseable key, but will be ignored")
+	defer os.Unsetenv("GIT_SSH_KEY")
+
+	a.username = "user"
+	a.privKey = testdata.PEMBytes["ed25519"]
+	am, err = a.Authenticate(tests.MustURL("ssh://example.com/foo"))
+	assert.NoError(t, err)
+	assert.IsType(t, &ssh.PublicKeys{}, am)
+
+	pk := am.(*ssh.PublicKeys)
+	assert.Equal(t, "user", pk.User)
+
+	// username in URL overrides provided
+	am, err = a.Authenticate(tests.MustURL("ssh://git@example.com/foo"))
+	assert.NoError(t, err)
+	assert.IsType(t, &ssh.PublicKeys{}, am)
+
+	pk = am.(*ssh.PublicKeys)
+	assert.Equal(t, "git", pk.User)
+}
+
+func TestSSHAgentAuthenticator(t *testing.T) {
+	if os.Getenv("SSH_AUTH_SOCK") == "" {
+		t.Skip("no SSH_AUTH_SOCK - skipping ssh agent test")
+	}
+
+	currentUser := ""
+	if u, err := user.Current(); err == nil {
+		currentUser = u.Username
+	} else {
+		currentUser = os.Getenv("USER")
+	}
+
+	require.NotEmpty(t, currentUser)
+
+	a := &sshAgentAuthenticator{}
+
+	// only valid for ssh schemes
+	_, err := a.Authenticate(tests.MustURL("file:///bare.git"))
+	assert.Error(t, err)
+
+	_, err = a.Authenticate(tests.MustURL("https:///bare.git"))
+	assert.Error(t, err)
+
+	// user defaults to current user
+	am, err := a.Authenticate(tests.MustURL("ssh://example.com/foo"))
+	assert.NoError(t, err)
+
+	pkc, ok := am.(*ssh.PublicKeysCallback)
+	assert.Equal(t, true, ok)
+	assert.Equal(t, currentUser, pkc.User)
+
+	// provided user overrides
+	a.username = "user"
+	am, err = a.Authenticate(tests.MustURL("ssh://example.com/foo"))
+	assert.NoError(t, err)
+
+	pkc, ok = am.(*ssh.PublicKeysCallback)
+	assert.Equal(t, true, ok)
+	assert.Equal(t, "user", pkc.User)
+
+	// username in URL overrides provided
+	am, err = a.Authenticate(tests.MustURL("ssh://git@example.com"))
+	assert.NoError(t, err)
+
+	pkc, ok = am.(*ssh.PublicKeysCallback)
+	assert.Equal(t, true, ok)
+	assert.Equal(t, "git", pkc.User)
+}

--- a/gitfs/doc.go
+++ b/gitfs/doc.go
@@ -1,0 +1,84 @@
+// Package gitfs provides a read-only filesystem backed by a git repository.
+//
+// This filesystem accesses the git state, and so for local repositories, files
+// not committed to a branch (i.e. "dirty" or modified files) will not be
+// visible.
+//
+// This filesystem's behaviour complies with fstest.TestFS.
+//
+// Usage
+//
+// To use this filesystem, call New with a base URL. All reads from the
+// filesystem are relative to this base URL. Valid schemes are 'git', 'file',
+// 'http', 'https', 'ssh', and the same prefixed with 'git+' (e.g.
+// 'git+ssh://example.com').
+//
+// URL Format
+//
+// The scheme, authority (with userinfo), path, and fragment are used by this
+// filesystem.
+//
+// Scheme may be one of:
+//
+// - 'git': use the classic Git protocol, as served by 'git daemon'
+//
+// - 'file': use the local filesystem (repo can be bare or not)
+//
+// - 'http'/'https': use the Smart HTTP protocol
+//
+// - 'ssh': use the SSH protocol
+//
+// See https://git-scm.com/book/en/v2/Git-on-the-Server-The-Protocols for more
+// on these protocols.
+//
+// Authority points to the remote git server hostname (and optional port, if
+// applicable). The userinfo subcomponent (i.e. 'user:password@...') can be used for
+// authenticated schemes like 'https' and 'ssh'.
+//
+// Path is a composite of the path to the repository and the path to a directory
+// referenced within. The '//' sequence (double forward-slash) is used to
+// separate the repository from the path. If no '//' is present in the path, the
+// filesystem will be rooted at the root directory of the repository.
+//
+// Fragment is used to specify which branch or tag to reference. When not
+// specified, the repository's default branch will be chosen.
+// Branches are referenced by short name (such as '#main') or by the long form
+// prefixed with '#refs/heads/'. Valid examples are '#develop',
+// '#refs/heads/mybranch', etc...
+// Tags are referenced by long form, prefixed with 'refs/tags/'. Valid examples
+// are '#refs/tags/v1', '#refs/tags/mytag', etc...
+//
+// Here are a few more examples of URLs valid for this filesystem:
+//
+//	git+https://github.com/hairyhenderson/gomplate//docs-src/content/functions
+//	git+file:///repos/go-which
+//	git+https://github.com/hairyhenderson/go-which//cmd/which#refs/tags/v0.1.0
+//	git+ssh://git@github.com/hairyhenderson/go-which.git
+//
+// Authentication
+//
+// The authentication mechanisms used by gitfs are dependent on the URL scheme.
+// A number of Authenticators are provided in this package. See the
+// documentation for the Authenticator type for more information.
+//
+// Environment Variables
+//
+// The Authenticators in this package optionally support the use of environment
+// variables to provide credentials. These are:
+//
+// - GIT_HTTP_PASSWORD: the password to use for HTTP Basic Authentication
+//
+// - GIT_HTTP_PASSWORD_FILE: the path to a file containing the password to use
+// for HTTP Basic Authentication
+//
+// - GIT_HTTP_TOKEN: the token to use for HTTP token authentication
+//
+// - GIT_HTTP_TOKEN_FILE: the path to a file containing the token to use for
+// HTTP token authentication
+//
+// - GIT_SSH_KEY: the (optionally Base64-encoded) PEM-encoded private key to use
+// for SSH public key authentication
+//
+// - GIT_SSH_KEY_FILE: the path to a file containing the PEM-encoded private key
+// to use for SSH public key authentication
+package gitfs

--- a/gitfs/example_test.go
+++ b/gitfs/example_test.go
@@ -1,0 +1,35 @@
+package gitfs
+
+import (
+	"fmt"
+	"io/fs"
+	"net/url"
+)
+
+// Using gitfs.New to create a filesystem based on a git repository on the
+// local filesystem.
+func Example() {
+	u, _ := url.Parse("file:///data/repo")
+	fsys, _ := New(u)
+
+	files, _ := fs.ReadDir(fsys, ".")
+	for _, name := range files {
+		fmt.Printf("file: %s\n", name.Name())
+	}
+}
+
+// Using WithAuthenticator to configure authentication using the ssh-agent
+// support.
+func Example_explicitAuth() {
+	u, _ := url.Parse("git+ssh://github.com/git-fixtures/basic//json#branch")
+
+	// create the FS and set SSH Agent authentication explicitly, setting the
+	// username to 'git', as GitHub requires.
+	fsys, _ := New(u)
+	fsys = WithAuthenticator(SSHAgentAuthenticator("git"), fsys)
+
+	files, _ := fs.ReadDir(fsys, ".")
+	for _, name := range files {
+		fmt.Printf("file: %s\n", name.Name())
+	}
+}

--- a/internal/tests/integration/gitfs_test.go
+++ b/internal/tests/integration/gitfs_test.go
@@ -144,6 +144,7 @@ func TestGitFS_Daemon(t *testing.T) {
 
 func TestGitFS_HTTPDatasource(t *testing.T) {
 	fsys, _ := gitfs.New(tests.MustURL("git+https://github.com/git-fixtures/basic//json/"))
+	fsys = gitfs.WithAuthenticator(gitfs.BasicAuthenticator("", ""), fsys)
 
 	files, err := fs.ReadDir(fsys, ".")
 	assert.NoError(t, err)
@@ -169,6 +170,7 @@ func TestGitFS_SSHDatasource(t *testing.T) {
 	}
 
 	fsys, _ := gitfs.New(tests.MustURL("git+ssh://git@github.com/git-fixtures/basic//json"))
+	fsys = gitfs.WithAuthenticator(gitfs.SSHAgentAuthenticator(""), fsys)
 
 	files, err := fs.ReadDir(fsys, ".")
 	assert.NoError(t, err)


### PR DESCRIPTION
Currently authentication in `gitfs` requires environment variables, which can make things difficult when writing code that may not have access to the environment, or when using `gitfs` concurrently against different repos.

This solves the problem by adding a `WithAuthenticator` wrapper function to compose a `gitfs.FS` with an authentication method. This is similar to the `vaultfs.WithAuthMethod` function, though in this case it needs to work slightly differently due to how the underlying `go-git` module works. I'm not that happy with naming, but we're pre-1.0 still, so that can change.

The previous behaviour is preserved by the `gitfs.AutoAuthenticator`, which will infer credentials from the URL or environment depending on the URL scheme.

Signed-off-by: Dave Henderson <dhenderson@gmail.com>