### PR TITLE
Attempt to make filesystem test less flakey on Windows

### DIFF
--- a/filefs/file_test.go
+++ b/filefs/file_test.go
@@ -4,6 +4,7 @@ import (
 	"net/url"
 	"testing"
 	"testing/fstest"
+	"time"
 
 	"github.com/hairyhenderson/go-fsimpl/internal/tests"
 	"github.com/stretchr/testify/assert"
@@ -11,10 +12,16 @@ import (
 )
 
 func setupFileSystem(t *testing.T) *tfs.Dir {
+	staticTimeStamps := tfs.WithTimestamps(
+		time.Date(2022, 8, 1, 13, 14, 15, 0, time.UTC),
+		time.Date(2022, 8, 1, 13, 14, 15, 0, time.UTC),
+	)
+
 	tmpDir := tfs.NewDir(t, "go-fsimplTests",
-		tfs.WithFile("hello.txt", "hello world\n"),
+		tfs.WithFile("hello.txt", "hello world\n", staticTimeStamps),
 		tfs.WithDir("sub",
-			tfs.WithFile("subfile.txt", "hi there"),
+			tfs.WithFile("subfile.txt", "hi there", staticTimeStamps),
+			staticTimeStamps,
 		),
 	)
 	t.Cleanup(tmpDir.Remove)

--- a/filefs/file_windows_test.go
+++ b/filefs/file_windows_test.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/hairyhenderson/go-fsimpl/internal/tests"
 	"github.com/stretchr/testify/assert"
@@ -15,10 +16,16 @@ import (
 )
 
 func setupWinFileSystem(t *testing.T) *tfs.Dir {
+	staticTimeStamps := tfs.WithTimestamps(
+		time.Date(2022, 8, 1, 13, 14, 15, 0, time.UTC),
+		time.Date(2022, 8, 1, 13, 14, 15, 0, time.UTC),
+	)
+
 	tmpDir := tfs.NewDir(t, "go-fsimplWinTests",
-		tfs.WithFile("hello.txt", "hello world\n"),
+		tfs.WithFile("hello.txt", "hello world\n", staticTimeStamps),
 		tfs.WithDir("sub",
-			tfs.WithFile("subfile.txt", "hi there"),
+			tfs.WithFile("subfile.txt", "hi there", staticTimeStamps),
+			staticTimeStamps,
 		),
 	)
 	t.Cleanup(tmpDir.Remove)


### PR DESCRIPTION
Sometimes I see failures like this when running `TestFileFS` on Windows:

```
--- FAIL: TestFileFS (0.06s)
    file_test.go:31: 
        	Error Trace:	D:\a\go-fsimpl\go-fsimpl\filefs\file_test.go:31
        	Error:      	Received unexpected error:
        	            	TestFS found errors:
        	            	sub: mismatch:
        	            		entry.Info() = sub IsDir=true Mode=drwxrwxrwx Size=0 ModTime=2022-08-21 16:02:47.0513102 +0000 GMT
        	            		file.Stat() = sub IsDir=true Mode=drwxrwxrwx Size=0 ModTime=2022-08-21 16:02:47.0518252 +0000 GMT
        	Test:       	TestFileFS
```

I'm not sure _why_ there are slightly-different ModTimes for the same directory, but in concept setting an explicit ModTime may help? 🤷‍♂️

Signed-off-by: Dave Henderson <dhenderson@gmail.com>