### PR TITLE
A few test tidy ups, including working with modern git

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,10 @@ func main() {
 }
 ```
 
+## Developing
+
+You will require `git` including `git daemon` and `consul` executables on your path for running the tests.
+
 ## License
 
 [The MIT License](http://opensource.org/licenses/MIT)

--- a/internal/tests/integration/gitfs_test.go
+++ b/internal/tests/integration/gitfs_test.go
@@ -22,7 +22,7 @@ import (
 )
 
 func setupGitFSTest(t *testing.T) *tfs.Dir {
-	tmpDir := tfs.NewDir(t, "gomplate-inttests",
+	tmpDir := tfs.NewDir(t, "gofsimpl-inttests",
 		tfs.WithDir("repo",
 			tfs.WithFiles(map[string]string{
 				"config.json": `{"foo": {"bar": "baz"}}`,
@@ -47,6 +47,11 @@ func setupGitFSTest(t *testing.T) *tfs.Dir {
 	result := icmd.RunCommand("git", "init", repoPath)
 	result.Assert(t, icmd.Expected{ExitCode: 0, Out: "Initialized empty Git repository"})
 
+	// Modern git >2.28 defaults to branch main. go-git expects master by default
+	// this is a no-op if we're already on master
+	result = icmd.RunCmd(icmd.Command("git", "branch", "-m", "master"), icmd.Dir(repoPath))
+	result.Assert(t, icmd.Expected{ExitCode: 0})
+
 	result = icmd.RunCmd(icmd.Command("git", "add", "-A"), icmd.Dir(repoPath))
 	result.Assert(t, icmd.Expected{ExitCode: 0})
 
@@ -59,7 +64,7 @@ func setupGitFSTest(t *testing.T) *tfs.Dir {
 func startGitDaemon(t *testing.T) string {
 	tmpDir := setupGitFSTest(t)
 
-	pidDir := tfs.NewDir(t, "gomplate-inttests-pid")
+	pidDir := tfs.NewDir(t, "gofsimpl-inttests-pid")
 	t.Cleanup(pidDir.Remove)
 
 	port, addr := freeport(t)


### PR DESCRIPTION
Some notes added on how to get the tests to pass.

Changed some of the gomplate temporary paths to gofsimpl paths instead.

git init with recent git creates a `main` branch not a `master` branch. This makes the test fail. As a simple workaround I've made sure we're on `master`.