### PR TITLE
vaultfs: Support K/V v2 secret engine

### DIFF
--- a/vaultfs/doc.go
+++ b/vaultfs/doc.go
@@ -31,6 +31,12 @@
 // that is, the "/v1" prefix is not needed, and with the K/V Version 2 secret
 // engine the "data" prefix should not be provided.
 //
+// When reading from K/V v2 secret engines, specific versions of the secret can
+// be read by providing a "version" query parameter. For example, to read the
+// fifth version of the secret at "secret/mysecret", you could use a URL like:
+//
+//	vault:///secret/mysecret?version=5
+//
 // See the Vault Secret Engines docs for more details:
 // https://vaultproject.io/docs/secrets.
 //

--- a/vaultfs/vault_test.go
+++ b/vaultfs/vault_test.go
@@ -250,9 +250,9 @@ func TestReadDirFS(t *testing.T) {
 	assert.NoError(t, err)
 
 	des := []fs.DirEntry{
-		internal.FileInfo("bar", 25, 0o644, time.Time{}, "application/json").(fs.DirEntry),
+		internal.FileInfo("bar", 15, 0o644, time.Time{}, "application/json").(fs.DirEntry),
 		internal.DirInfo("bazDir", time.Time{}).(fs.DirEntry),
-		internal.FileInfo("foo", 25, 0o644, time.Time{}, "application/json").(fs.DirEntry),
+		internal.FileInfo("foo", 15, 0o644, time.Time{}, "application/json").(fs.DirEntry),
 	}
 	assert.EqualValues(t, des, de)
 
@@ -263,9 +263,9 @@ func TestReadDirFS(t *testing.T) {
 	assert.NoError(t, err)
 
 	des = []fs.DirEntry{
-		internal.FileInfo("bar", 25, 0o644, time.Time{}, "application/json").(fs.DirEntry),
+		internal.FileInfo("bar", 15, 0o644, time.Time{}, "application/json").(fs.DirEntry),
 		internal.DirInfo("bazDir", time.Time{}).(fs.DirEntry),
-		internal.FileInfo("foo", 25, 0o644, time.Time{}, "application/json").(fs.DirEntry),
+		internal.FileInfo("foo", 15, 0o644, time.Time{}, "application/json").(fs.DirEntry),
 	}
 	assert.EqualValues(t, des, de)
 }
@@ -289,7 +289,7 @@ func TestReadDirN(t *testing.T) {
 	assert.NoError(t, err)
 
 	des := []fs.DirEntry{
-		internal.FileInfo("foo", 25, 0o644, time.Time{}, "application/json").(fs.DirEntry),
+		internal.FileInfo("foo", 15, 0o644, time.Time{}, "application/json").(fs.DirEntry),
 	}
 	assert.EqualValues(t, des, de)
 
@@ -297,7 +297,7 @@ func TestReadDirN(t *testing.T) {
 	assert.NoError(t, err)
 
 	des = []fs.DirEntry{
-		internal.FileInfo("bar", 25, 0o644, time.Time{}, "application/json").(fs.DirEntry),
+		internal.FileInfo("bar", 15, 0o644, time.Time{}, "application/json").(fs.DirEntry),
 		internal.DirInfo("bazDir", time.Time{}).(fs.DirEntry),
 	}
 	assert.EqualValues(t, des, de)
@@ -451,4 +451,28 @@ func TestFileAuthCaching(t *testing.T) {
 	err = f2.Close()
 	assert.NoError(t, err)
 	assert.False(t, am.loggedin)
+}
+
+func TestCreatedTimeFromData(t *testing.T) {
+	// missing metadata, KV v1 style
+	created := createdTimeFromData(map[string]interface{}{"value": "ahoy"})
+	assert.Equal(t, time.Time{}, created)
+
+	created = createdTimeFromData(map[string]interface{}{"metadata": nil})
+	assert.Equal(t, time.Time{}, created)
+
+	created = createdTimeFromData(map[string]interface{}{
+		"metadata": map[string]interface{}{
+			"created_time": 42}})
+	assert.Equal(t, time.Time{}, created)
+
+	created = createdTimeFromData(map[string]interface{}{
+		"metadata": map[string]interface{}{
+			"created_time": "not a time"}})
+	assert.Equal(t, time.Time{}, created)
+
+	created = createdTimeFromData(map[string]interface{}{
+		"metadata": map[string]interface{}{
+			"created_time": "2022-09-12T00:22:20.370537Z"}})
+	assert.Equal(t, time.Date(2022, 9, 12, 0, 22, 20, 370537000, time.UTC), created)
 }


### PR DESCRIPTION
Fixes #24 

This adds support for the [K/V v2](https://www.vaultproject.io/docs/secrets/kv/kv-v2) secrets mounts. It can be used in exactly the same way that K/V v1 mounts are used (same URL scheme, etc). The one difference is that a `?version=` query parameter can be sent to request previous secret versions.

In this implementation, a check is made prior to accessing the mount to find out what version of the `kv` engine is in use. Currently this is done on every access, doubling the number of requests. In future it may be useful to add some caching to improve performance - _however_ because it is possible to upgrade a kv-v1 mount to kv-v2 at runtime, this will be a bit more complex to get right.

Signed-off-by: Dave Henderson <dhenderson@gmail.com>