### PR TITLE
Upgrade AWS SDK deps and fix API breakage

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -23,7 +23,6 @@ linters:
   enable:
     - asciicheck
     - bodyclose
-    - deadcode
     - depguard
     - dogsled
     - dupl
@@ -62,13 +61,11 @@ linters:
     - rowserrcheck
     - sqlclosecheck
     - staticcheck
-    - structcheck
     - stylecheck
     - typecheck
     - unconvert
     - unparam
     - unused
-    - varcheck
     - whitespace
     - wsl
 

--- a/awssmfs/awssm.go
+++ b/awssmfs/awssm.go
@@ -272,7 +272,7 @@ func (f *awssmFile) Stat() (fs.FileInfo, error) {
 	// no need for special handling for opaque paths, as "." will never hit this
 	// code path (Open sets f.fi to a DirInfo)
 	filters := []smtypes.Filter{{Key: "name", Values: []string{path.Join(f.root, f.name) + "/"}}}
-	params := secretsmanager.ListSecretsInput{MaxResults: 1, Filters: filters}
+	params := secretsmanager.ListSecretsInput{MaxResults: aws.Int32(1), Filters: filters}
 
 	secrets, err := f.client.ListSecrets(f.ctx, &params)
 	if err != nil {

--- a/awssmfs/fake_client_test.go
+++ b/awssmfs/fake_client_test.go
@@ -98,13 +98,13 @@ func (c *fakeClient) ListSecrets(ctx context.Context, params *secretsmanager.Lis
 		return aws.ToString(secretList[i].Name) < aws.ToString(secretList[j].Name)
 	})
 
-	if params.MaxResults == 0 {
+	if params.MaxResults == nil || params.MaxResults == aws.Int32(0) {
 		// default to 2 results so we trigger pagination
-		params.MaxResults = 2
+		params.MaxResults = aws.Int32(2)
 	}
 
 	l := len(secretList)
-	m := int(params.MaxResults)
+	m := int(*params.MaxResults)
 
 	high := offset + m
 

--- a/awssmpfs/awssmp.go
+++ b/awssmpfs/awssmp.go
@@ -231,7 +231,7 @@ func (f *awssmpFS) ReadFile(name string) ([]byte, error) {
 	out, err := smclient.GetParameter(f.ctx, &ssm.GetParameterInput{
 		Name: aws.String(path.Join(f.root, name)),
 		// decrypt the parameter if it's a SecureString
-		WithDecryption: true,
+		WithDecryption: aws.Bool(true),
 	})
 	if err != nil {
 		return nil, &fs.PathError{Op: "readFile", Path: name, Err: convertAWSError(err)}
@@ -289,7 +289,7 @@ func (f *awssmpFile) Stat() (fs.FileInfo, error) {
 	// code path (Open sets f.fi to a DirInfo)
 	params, err := f.client.GetParametersByPath(f.ctx, &ssm.GetParametersByPathInput{
 		Path:      aws.String(path.Join(f.root, f.name) + "/"),
-		Recursive: true,
+		Recursive: aws.Bool(true),
 	})
 	if err != nil {
 		return nil, &fs.PathError{Op: "stat", Path: f.name, Err: convertAWSError(err)}
@@ -336,7 +336,7 @@ func (f *awssmpFile) getParameter() error {
 
 	out, err := f.client.GetParameter(f.ctx, &ssm.GetParameterInput{
 		Name:           aws.String(fullPath),
-		WithDecryption: true,
+		WithDecryption: aws.Bool(true),
 	})
 	if err != nil {
 		return fmt.Errorf("getParameter: %w", convertAWSError(err))
@@ -384,9 +384,9 @@ func (f *awssmpFile) listParameters() ([]types.Parameter, error) {
 	for token := (*string)(nil); ; {
 		out, err := f.client.GetParametersByPath(f.ctx, &ssm.GetParametersByPathInput{
 			Path:           aws.String(prefix),
-			WithDecryption: true,
+			WithDecryption: aws.Bool(true),
 			NextToken:      token,
-			Recursive:      true,
+			Recursive:      aws.Bool(true),
 		})
 		if err != nil {
 			return nil, fmt.Errorf("getParametersByPath: %w", err)

--- a/awssmpfs/fake_client_test.go
+++ b/awssmpfs/fake_client_test.go
@@ -50,7 +50,7 @@ func (c *fakeClient) GetParameter(ctx context.Context, params *ssm.GetParameterI
 	}
 }
 
-//nolint:funlen
+//nolint:funlen,gocyclo
 func (c *fakeClient) GetParametersByPath(ctx context.Context, params *ssm.GetParametersByPathInput,
 	optFns ...func(*ssm.Options)) (out *ssm.GetParametersByPathOutput, err error) {
 	c.t.Helper()
@@ -88,13 +88,13 @@ func (c *fakeClient) GetParametersByPath(ctx context.Context, params *ssm.GetPar
 		return aws.ToString(paramList[i].Name) < aws.ToString(paramList[j].Name)
 	})
 
-	if params.MaxResults == 0 {
+	if params.MaxResults == nil || params.MaxResults == aws.Int32(0) {
 		// default to 2 results so we trigger pagination
-		params.MaxResults = 2
+		params.MaxResults = aws.Int32(2)
 	}
 
 	l := len(paramList)
-	m := int(params.MaxResults)
+	m := int(*params.MaxResults)
 
 	high := offset + m
 

--- a/go.mod
+++ b/go.mod
@@ -7,8 +7,8 @@ require (
 	github.com/aws/aws-sdk-go v1.44.100
 	github.com/aws/aws-sdk-go-v2 v1.16.15
 	github.com/aws/aws-sdk-go-v2/config v1.17.6
-	github.com/aws/aws-sdk-go-v2/service/secretsmanager v1.15.22
-	github.com/aws/aws-sdk-go-v2/service/ssm v1.27.13
+	github.com/aws/aws-sdk-go-v2/service/secretsmanager v1.16.0
+	github.com/aws/aws-sdk-go-v2/service/ssm v1.28.0
 	github.com/fsouza/fake-gcs-server v1.40.1
 	github.com/go-git/go-billy/v5 v5.3.1
 	github.com/go-git/go-git/v5 v5.4.2

--- a/go.sum
+++ b/go.sum
@@ -171,7 +171,6 @@ github.com/aws/aws-sdk-go v1.44.100 h1:7I86bWNQB+HGDT5z/dJy61J7qgbgLoZ7O51C9eL6h
 github.com/aws/aws-sdk-go v1.44.100/go.mod h1:y4AeaBuwd2Lk+GepC1E9v0qOiTws0MIWAX4oIKwKHZo=
 github.com/aws/aws-sdk-go-v2 v1.16.2/go.mod h1:ytwTPBG6fXTZLxxeeCCWj2/EMYp/xDUgX+OET6TLNNU=
 github.com/aws/aws-sdk-go-v2 v1.16.4/go.mod h1:ytwTPBG6fXTZLxxeeCCWj2/EMYp/xDUgX+OET6TLNNU=
-github.com/aws/aws-sdk-go-v2 v1.16.14/go.mod h1:s/G+UV29dECbF5rf+RNj1xhlmvoNurGSr+McVSRj59w=
 github.com/aws/aws-sdk-go-v2 v1.16.15 h1:2sInOWGE4HV54R90Pj8QgqBBw3Qf1I0husqbqjPZzys=
 github.com/aws/aws-sdk-go-v2 v1.16.15/go.mod h1:SwiyXi/1zTUZ6KIAmLK5V5ll8SiURNUYOqTerZPaF9k=
 github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.4.1 h1:SdK4Ppk5IzLs64ZMvr6MrSficMtjY2oS0WOORXTlxwU=
@@ -193,12 +192,10 @@ github.com/aws/aws-sdk-go-v2/feature/s3/manager v1.11.14 h1:qpJmFbypCfwPok5PGTSn
 github.com/aws/aws-sdk-go-v2/feature/s3/manager v1.11.14/go.mod h1:IOYB+xOZik8YgdTlnDSwbvKmCkikA3nVue8/Qnfzs0c=
 github.com/aws/aws-sdk-go-v2/internal/configsources v1.1.9/go.mod h1:AnVH5pvai0pAF4lXRq0bmhbes1u9R8wTE+g+183bZNM=
 github.com/aws/aws-sdk-go-v2/internal/configsources v1.1.11/go.mod h1:tmUB6jakq5DFNcXsXOA/ZQ7/C8VnSKYkx58OI7Fh79g=
-github.com/aws/aws-sdk-go-v2/internal/configsources v1.1.21/go.mod h1:XsmHMV9c512xgsW01q7H0ut+UQQQpWX8QsFbdLHDwaU=
 github.com/aws/aws-sdk-go-v2/internal/configsources v1.1.22 h1:pE27/u2A7JlwICjOvONQDob8PToShRTkuiUE74ymVWg=
 github.com/aws/aws-sdk-go-v2/internal/configsources v1.1.22/go.mod h1:/vNv5Al0bpiF8YdX2Ov6Xy05VTiXsql94yUqJMYaj0w=
 github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.4.3/go.mod h1:ssOhaLpRlh88H3UmEcsBoVKq309quMvm3Ds8e9d4eJM=
 github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.4.5/go.mod h1:fV1AaS2gFc1tM0RCb015FJ0pvWVUfJZANzjwoO4YakM=
-github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.4.15/go.mod h1:kjJ4CyD9M3Wq88GYg3IPfj67Rs0Uvz8aXK7MJ8BvE4I=
 github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.4.16 h1:L5LKGHHXOl4t7+5QZMTl38GIzSAq07XUTRtEquiHGMA=
 github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.4.16/go.mod h1:62dsXI0BqTIGomDl8Hpm33dv0OntGaVblri3ZRParVQ=
 github.com/aws/aws-sdk-go-v2/internal/ini v1.3.10/go.mod h1:8DcYQcz0+ZJaSxANlHIsbbi6S+zMwjwdDqwW3r9AzaE=
@@ -224,13 +221,13 @@ github.com/aws/aws-sdk-go-v2/service/s3 v1.26.3/go.mod h1:g1qvDuRsJY+XghsV6zg00Z
 github.com/aws/aws-sdk-go-v2/service/s3 v1.26.10 h1:GWdLZK0r1AK5sKb8rhB9bEXqXCK8WNuyv4TBAD6ZviQ=
 github.com/aws/aws-sdk-go-v2/service/s3 v1.26.10/go.mod h1:+O7qJxF8nLorAhuIVhYTHse6okjHJJm4EwhhzvpnkT0=
 github.com/aws/aws-sdk-go-v2/service/secretsmanager v1.15.4/go.mod h1:PJc8s+lxyU8rrre0/4a0pn2wgwiDvOEzoOjcJUBr67o=
-github.com/aws/aws-sdk-go-v2/service/secretsmanager v1.15.22 h1:ggHTCgbIivTM85PFjv/rkJbchrmLSNL+Vcj5hg54TyM=
-github.com/aws/aws-sdk-go-v2/service/secretsmanager v1.15.22/go.mod h1:zT2j7Ndi+FcBX+zfYLDppqODSgSdKlquB3LPLPVDAts=
+github.com/aws/aws-sdk-go-v2/service/secretsmanager v1.16.0 h1:Lh1yssM4dinNZuESsXnbi+pID8hoviejLZdLmT175i8=
+github.com/aws/aws-sdk-go-v2/service/secretsmanager v1.16.0/go.mod h1:z0y2iDaghoq7uv6kndhrJCTzgVckv8Aak8kpnu2kYjs=
 github.com/aws/aws-sdk-go-v2/service/sns v1.17.4/go.mod h1:kElt+uCcXxcqFyc+bQqZPFD9DME/eC6oHBXvFzQ9Bcw=
 github.com/aws/aws-sdk-go-v2/service/sqs v1.18.3/go.mod h1:skmQo0UPvsjsuYYSYMVmrPc1HWCbHUJyrCEp+ZaLzqM=
 github.com/aws/aws-sdk-go-v2/service/ssm v1.24.1/go.mod h1:NR/xoKjdbRJ+qx0pMR4mI+N/H1I1ynHwXnO6FowXJc0=
-github.com/aws/aws-sdk-go-v2/service/ssm v1.27.13 h1:frTWO9DxuGG9zzV5F3gvc9ondPUd/Ae7x1lXJt+4Fwg=
-github.com/aws/aws-sdk-go-v2/service/ssm v1.27.13/go.mod h1:DLGkJX+FzEhluRGOTf9eejrDPu1gZ+1GuNkgLYdnPFM=
+github.com/aws/aws-sdk-go-v2/service/ssm v1.28.0 h1:R7lLqiY82XTxaaLQzHbBH8Wy3ScW5pyUTDd7Lag7JzY=
+github.com/aws/aws-sdk-go-v2/service/ssm v1.28.0/go.mod h1:9e3tFB+oyarkxO2bwbUa/bwke1K8wkmNk2QEc/5MaVA=
 github.com/aws/aws-sdk-go-v2/service/sso v1.11.3/go.mod h1:7UQ/e69kU7LDPtY40OyoHYgRmgfGM4mgsLYtcObdveU=
 github.com/aws/aws-sdk-go-v2/service/sso v1.11.7/go.mod h1:TFVe6Rr2joVLsYQ1ABACXgOC6lXip/qpX2x5jWg/A9w=
 github.com/aws/aws-sdk-go-v2/service/sso v1.11.22 h1:LrEyMbp0gMiXVaXpJ67jJkkqKCxivZvOd6wgXem0bWA=
@@ -242,7 +239,6 @@ github.com/aws/aws-sdk-go-v2/service/sts v1.16.6/go.mod h1:rP1rEOKAGZoXp4iGDxSXF
 github.com/aws/aws-sdk-go-v2/service/sts v1.16.18 h1:TqEvnK8OceCKNQaDK9d5Ir2bOtC0S0dRQCwSbkV1rz0=
 github.com/aws/aws-sdk-go-v2/service/sts v1.16.18/go.mod h1:AE4zMc8qCw1JnDvy0ZrDVb/OXRuuweG3BcT2Nv7Qh3E=
 github.com/aws/smithy-go v1.11.2/go.mod h1:3xHYmszWVx2c0kIwQeEVf9uSm4fYZt67FBJnwub1bgM=
-github.com/aws/smithy-go v1.13.2/go.mod h1:Tg+OJXh4MB2R/uN61Ko2f6hTZwB/ZYGOtib8J3gBHzA=
 github.com/aws/smithy-go v1.13.3 h1:l7LYxGuzK6/K+NzJ2mC+VvLUbae0sL3bXU//04MkmnA=
 github.com/aws/smithy-go v1.13.3/go.mod h1:Tg+OJXh4MB2R/uN61Ko2f6hTZwB/ZYGOtib8J3gBHzA=
 github.com/benbjohnson/clock v1.1.0/go.mod h1:J11/hYXuz8f4ySSvYwY0FKfm+ezbsZBKZxNJlLklBHA=


### PR DESCRIPTION
Supersedes https://github.com/hairyhenderson/go-fsimpl/pull/154 and https://github.com/hairyhenderson/go-fsimpl/pull/157

A few parameters in the SSM and SM SDKs were concrete types where they were intended to be pointers. This was fixed in recent versions.

Signed-off-by: Dave Henderson <dhenderson@gmail.com>