### PR TITLE
Add kubernetes vault auth

### DIFF
--- a/vaultfs/auth.go
+++ b/vaultfs/auth.go
@@ -396,7 +396,7 @@ func (m *kubernetesAuthMethod) Login(ctx context.Context, client *api.Client) er
 	}
 
 	if len(jwt) == 0 {
-		return fmt.Errorf("kubernetes auth failure: no jwt found at %s", jwtPath)
+		return fmt.Errorf("kubernetes auth failure: file %q is empty", jwtPath)
 	}
 
 	mount := findValue(m.mount, "VAULT_AUTH_KUBERNETES_MOUNT", "kubernetes", m.fsys)

--- a/vaultfs/auth_test.go
+++ b/vaultfs/auth_test.go
@@ -272,7 +272,7 @@ func TestAppIDAuthMethod(t *testing.T) {
 
 func TestKubernetesAuthMethod(t *testing.T) {
 	mount := "kubernetes"
-	jwtPath := "tmp/file"
+	saTokenPath := "tmp/file"
 	role := "alice"
 	token := "k8stoken"
 
@@ -293,7 +293,7 @@ func TestKubernetesAuthMethod(t *testing.T) {
 	defer cancel()
 
 	fsys := fstest.MapFS{}
-	fsys[jwtPath] = &fstest.MapFile{Data: []byte("tempfiletoken")}
+	fsys[saTokenPath] = &fstest.MapFile{Data: []byte("tempfiletoken")}
 
 	m := KubernetesAuthMethod("", "", "")
 	err := m.Login(ctx, client)
@@ -303,13 +303,13 @@ func TestKubernetesAuthMethod(t *testing.T) {
 	err = m.Login(ctx, client)
 	assert.Error(t, err)
 
-	m = &kubernetesAuthMethod{fsys: fsys, role: role, jwtPath: jwtPath}
+	m = &kubernetesAuthMethod{fsys: fsys, role: role, saTokenPath: saTokenPath}
 	err = m.Login(ctx, client)
 	assert.NoError(t, err)
 	assert.Equal(t, token, client.Token())
 
 	mount = "setenrebuk"
-	m = &kubernetesAuthMethod{fsys: fsys, role: role, jwtPath: jwtPath, mount: mount}
+	m = &kubernetesAuthMethod{fsys: fsys, role: role, saTokenPath: saTokenPath, mount: mount}
 	err = m.Login(ctx, client)
 	assert.NoError(t, err)
 	assert.Equal(t, token, client.Token())


### PR DESCRIPTION
This addresses #152. Please do ask for changes if you don't like it, although I'm busy the beginning of this week.

This uses a jwt token usually mounted at a well known location to authenticate as a 'role' in vault which must be provided via the environment.

See https://www.vaultproject.io/docs/auth/kubernetes