### PR TITLE
fix: fsimpl.ContentType should fallback to extension-guessing

### DIFF
--- a/extensions.go
+++ b/extensions.go
@@ -57,17 +57,22 @@ var (
 	extraMimeInit sync.Once
 )
 
-// ContentType returns the MIME content type for the given fs.FileInfo. If fi
-// has a ContentType method, that will be used, otherwise the type will be
-// guessed by the filename's extension. See the docs for mime.TypeByExtension
-// for details on how extension lookup works.
-// Some additional
+// ContentType returns the MIME content type for the given [io/fs.FileInfo]. If
+// fi has a ContentType method, it will be used first, otherwise the filename's
+// extension will be used. See the docs for [mime.TypeByExtension] for details
+// on how extension lookup works.
 //
-// The returned value may have parameters (e.g. "application/json; charset=utf-8")
-// which can be parsed with mime.ParseMediaType.
+// The returned value may have parameters (e.g.
+// "application/json; charset=utf-8") which can be parsed with
+// [mime.ParseMediaType].
 func ContentType(fi fs.FileInfo) string {
+	ct := ""
 	if cf, ok := fi.(internal.ContentTypeFileInfo); ok {
-		return cf.ContentType()
+		ct = cf.ContentType()
+	}
+
+	if ct != "" {
+		return ct
 	}
 
 	extraMimeInit.Do(func() {
@@ -78,6 +83,7 @@ func ContentType(fi fs.FileInfo) string {
 
 	// fall back to guessing based on extension
 	ext := filepath.Ext(fi.Name())
+	ct = mime.TypeByExtension(ext)
 
-	return mime.TypeByExtension(ext)
+	return ct
 }

--- a/extensions_test.go
+++ b/extensions_test.go
@@ -1,0 +1,23 @@
+package fsimpl
+
+import (
+	"testing"
+	"time"
+
+	"github.com/hairyhenderson/go-fsimpl/internal"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestContentType(t *testing.T) {
+	fi := internal.FileInfo("foo", 0, 0, time.Time{}, "")
+	assert.Equal(t, "", ContentType(fi))
+
+	fi = internal.FileInfo("foo", 0, 0, time.Time{}, "text/plain")
+	assert.Equal(t, "text/plain", ContentType(fi))
+
+	fi = internal.FileInfo("foo.json", 0, 0, time.Time{}, "text/plain")
+	assert.Equal(t, "text/plain", ContentType(fi))
+
+	fi = internal.FileInfo("foo.json", 0, 0, time.Time{}, "")
+	assert.Equal(t, "application/json", ContentType(fi))
+}


### PR DESCRIPTION
This wasn't really a bug, it was just surprising behaviour. When using `fsimpl.ContentType`, I would _expect_ it to fall back to guessing based on file extension when `fi` has a `ContentType` method that returns an empty string.

This fixes that behaviour.

Signed-off-by: Dave Henderson <dhenderson@gmail.com>