### PR TITLE
Temporarily support AppID auth method while vaultfs.AuthMethod is still supported

### DIFF
--- a/internal/tests/integration/vaultfs_test.go
+++ b/internal/tests/integration/vaultfs_test.go
@@ -518,6 +518,11 @@ func TestVaultFS_AppRoleAuth_ReusedToken(t *testing.T) {
 
 //nolint:errcheck
 func TestVaultFS_AppIDAuth(t *testing.T) {
+	// temporarily allow the deprecated pending-removal appID auth method
+	// when this starts failing completely, we should remove support
+	_ = os.Setenv("VAULT_ALLOW_PENDING_REMOVAL_MOUNTS", "true")
+	defer os.Unsetenv("VAULT_ALLOW_PENDING_REMOVAL_MOUNTS")
+
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 


### PR DESCRIPTION


Signed-off-by: Dave Henderson <dhenderson@gmail.com>