### PR TITLE
build fscli binary in CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,6 +18,20 @@ jobs:
       - uses: actions/checkout@v3
       - run: make test
       - run: make test-race
+  fscli-build:
+    runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/hairyhenderson/gomplate-ci-build:latest
+    steps:
+      - uses: actions/checkout@v3
+      - run: |
+          make bin/fscli_linux-amd64
+          make bin/fscli_linux-arm-v7
+          make bin/fscli_linux-arm64
+          make bin/fscli_linux-ppc64le
+          make bin/fscli_darwin-amd64
+          make bin/fscli_darwin-arm64
+          make bin/fscli_windows-amd64.exe
   windows-build:
     runs-on: windows-latest
     env:
@@ -26,7 +40,7 @@ jobs:
       - run: pwd
       - uses: actions/setup-go@v3
         with:
-          go-version: 1.18.x
+          go-version: 1.19.x
       - run: |
           git config --global user.email "bogus@example.com"
           git config --global user.name "Someone"

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,6 @@
 report.xml
 *.out
 _*.go
+
+dist/
+bin/

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,19 @@
 .DEFAULT_GOAL = test
 
+extension = $(patsubst windows,.exe,$(filter windows,$(1)))
+GOOS ?= $(shell go version | sed 's/^.*\ \([a-z0-9]*\)\/\([a-z0-9]*\)/\1/')
+GOARCH ?= $(shell go version | sed 's/^.*\ \([a-z0-9]*\)\/\([a-z0-9]*\)/\2/')
+
+ifeq ("$(TARGETVARIANT)","")
+ifneq ("$(GOARM)","")
+TARGETVARIANT := v$(GOARM)
+endif
+else
+ifeq ("$(GOARM)","")
+GOARM ?= $(subst v,,$(TARGETVARIANT))
+endif
+endif
+
 ifeq ("$(CI)","true")
 LINT_PROCS ?= 1
 else
@@ -12,11 +26,38 @@ test:
 test-race:
 	go test -race -coverprofile=c.out ./...
 
+bin/fscli_%v7$(call extension,$(GOOS)): $(shell find . -type f -name "*.go")
+	GOOS=$(shell echo $* | cut -f1 -d-) \
+	GOARCH=$(shell echo $* | cut -f2 -d- ) \
+	GOARM=7 \
+	CGO_ENABLED=0 \
+		go build -o $@ ./examples/fscli
+
+bin/fscli_windows-%.exe: $(shell find . -type f -name "*.go")
+	GOOS=windows \
+	GOARCH=$* \
+	GOARM= \
+	CGO_ENABLED=0 \
+		go build -o $@ ./examples/fscli
+
+bin/fscli_%$(TARGETVARIANT)$(call extension,$(GOOS)): $(shell find . -type f -name "*.go")
+	GOOS=$(shell echo $* | cut -f1 -d-) \
+	GOARCH=$(shell echo $* | cut -f2 -d- ) \
+	GOARM=$(GOARM) \
+	CGO_ENABLED=0 \
+		go build -o $@ ./examples/fscli
+
 lint:
 	@golangci-lint run --verbose --max-same-issues=0 --max-issues-per-linter=0
 
 ci-lint:
 	@golangci-lint run --verbose --max-same-issues=0 --max-issues-per-linter=0 --out-format=github-actions
+
+ifneq ("$(VERSION)","")
+release:
+	git tag -sm "Releasing v$(VERSION)" v$(VERSION) && git push --tags
+	gh release create v$(VERSION) --draft --generate-notes
+endif
 
 .PHONY: test lint ci-lint
 .DELETE_ON_ERROR:


### PR DESCRIPTION
Adds a `fscli-build` job to attempt to build the `fscli` binary (from `./examples/fscli`), which should expose bugs involving CGO (like what happened in #64).

Also adds a `release` make target - I'll be releasing v0.1.0 soon!

Signed-off-by: Dave Henderson <dhenderson@gmail.com>