### PR TITLE
Fix gitfs Windows-specific bugs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -59,6 +59,28 @@ release:
 	gh release create v$(VERSION) --draft --generate-notes
 endif
 
+# this is a special target for testing a package on Windows from a non-Windows
+# host. It builds the Windows test binary, then SCPs it to the Windows host, and
+# runs the tests there. This depends on the GO_REMOTE_WINDOWS environment
+# variable being set as 'username@host'. The Windows host must have Git Bash
+# installed, or maybe MSYS2, so that a number of standard Unix tools are
+# available. Git must also be configured with a username and email address. See
+# the GitHub workflow config in .github/workflows/build.yml for hints.
+# A recent PowerShell is also required, such as version 7.3 or later.
+#
+# An F: drive is expected to be available, with a tmp directory. This is used
+# to make sure we can deal with files on a different volume.
+.SECONDEXPANSION:
+$(shell go list -f '{{ if not (eq "" (join .TestGoFiles "")) }}testbin/{{.ImportPath}}.test.exe.remote{{end}}' ./...): $$(shell go list -f '{{.Dir}}' $$(subst testbin/,,$$(subst .test.exe.remote,,$$@)))
+	@echo $<
+	@GOOS=windows GOARCH=amd64 CGO_ENABLED=0 go test -tags timetzdata -c -o ./testbin/remote-test.exe $<
+	@scp -q ./testbin/remote-test.exe $(GO_REMOTE_WINDOWS):/$(shell ssh $(GO_REMOTE_WINDOWS) 'echo %TEMP%' | cut -f2 -d= | sed -e 's#\\#/#g')/
+	@ssh -o 'SetEnv TMP=F:\tmp' $(GO_REMOTE_WINDOWS) '%TEMP%\remote-test.exe'
+
+# test-remote-windows runs the above target for all packages that have tests
+test-remote-windows: $(shell go list -f '{{ if not (eq "" (join .TestGoFiles "")) }}testbin/{{.ImportPath}}.test.exe.remote{{end}}' ./...)
+
+
 .PHONY: test lint ci-lint
 .DELETE_ON_ERROR:
 .SECONDARY:

--- a/gitfs/git_test.go
+++ b/gitfs/git_test.go
@@ -216,7 +216,7 @@ func setupGitRepo(t *testing.T) map[string]string {
 
 func TestGitFS(t *testing.T) {
 	if runtime.GOOS == "windows" {
-		t.Skip("not running on Windows yet...")
+		t.Skip("not running on Windows")
 	}
 
 	_ = setupGitRepo(t)

--- a/go.mod
+++ b/go.mod
@@ -10,8 +10,6 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/secretsmanager v1.23.2
 	github.com/aws/aws-sdk-go-v2/service/ssm v1.43.1
 	github.com/fsouza/fake-gcs-server v1.47.6
-	github.com/go-git/go-billy/v5 v5.5.0
-	github.com/go-git/go-git/v5 v5.10.0
 	github.com/hashicorp/consul/api v1.26.1
 	github.com/hashicorp/vault/api v1.10.0
 	github.com/hashicorp/vault/api/auth/approle v0.5.0
@@ -21,6 +19,16 @@ require (
 	gocloud.dev v0.34.0
 	golang.org/x/crypto v0.15.0
 	gotest.tools/v3 v3.5.1
+)
+
+// TODO: once https://github.com/go-git/go-git/pull/416 is merged, this can be
+// removed and we can use the upstream module. This commit on my fork is a
+// cherry-pick from the PR on top of v5.10.0
+replace github.com/go-git/go-git/v5 => github.com/hairyhenderson/go-git/v5 v5.0.0-20231120010526-e49f9324b2fc
+
+require (
+	github.com/go-git/go-billy/v5 v5.5.0
+	github.com/go-git/go-git/v5 v5.10.0
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -163,8 +163,6 @@ github.com/go-git/go-billy/v5 v5.5.0 h1:yEY4yhzCDuMGSv83oGxiBotRzhwhNr8VZyphhiu+
 github.com/go-git/go-billy/v5 v5.5.0/go.mod h1:hmexnoNsr2SJU1Ju67OaNz5ASJY3+sHgFRpCtpDCKow=
 github.com/go-git/go-git-fixtures/v4 v4.3.2-0.20231010084843-55a94097c399 h1:eMje31YglSBqCdIqdhKBW8lokaMrL3uTkpGYlE2OOT4=
 github.com/go-git/go-git-fixtures/v4 v4.3.2-0.20231010084843-55a94097c399/go.mod h1:1OCfN199q1Jm3HZlxleg+Dw/mwps2Wbk9frAWm+4FII=
-github.com/go-git/go-git/v5 v5.10.0 h1:F0x3xXrAWmhwtzoCokU4IMPcBdncG+HAAqi9FcOOjbQ=
-github.com/go-git/go-git/v5 v5.10.0/go.mod h1:1FOZ/pQnqw24ghP2n7cunVl0ON55BsjPYvhWHvZGhoo=
 github.com/go-jose/go-jose/v3 v3.0.0/go.mod h1:RNkWWRld676jZEYoV3+XK8L2ZnNSvIsxFMht0mSX+u8=
 github.com/go-jose/go-jose/v3 v3.0.1 h1:pWmKFVtt+Jl0vBZTIpz/eAKwsm6LkIxDVVbFHKkchhA=
 github.com/go-jose/go-jose/v3 v3.0.1/go.mod h1:RNkWWRld676jZEYoV3+XK8L2ZnNSvIsxFMht0mSX+u8=
@@ -235,6 +233,8 @@ github.com/gorilla/handlers v1.5.1 h1:9lRY6j8DEeeBT10CvO9hGW0gmky0BprnvDI5vfhUHH
 github.com/gorilla/handlers v1.5.1/go.mod h1:t8XrUpc4KVXb7HGyJ4/cEnwQiaxrX/hz1Zv/4g96P1Q=
 github.com/gorilla/mux v1.8.0 h1:i40aqfkR1h2SlN9hojwV5ZA91wcXFOvkdNIeFDP5koI=
 github.com/gorilla/mux v1.8.0/go.mod h1:DVbg23sWSpFRCP0SfiEN6jmj59UnW/n46BH5rLB71So=
+github.com/hairyhenderson/go-git/v5 v5.0.0-20231120010526-e49f9324b2fc h1:FILALvLdfP7EBxJhJ6XbVYCSO7vw2jhatDjokNKKEWs=
+github.com/hairyhenderson/go-git/v5 v5.0.0-20231120010526-e49f9324b2fc/go.mod h1:1FOZ/pQnqw24ghP2n7cunVl0ON55BsjPYvhWHvZGhoo=
 github.com/hashicorp/consul/api v1.26.1 h1:5oSXOO5fboPZeW5SN+TdGFP/BILDgBm19OrPZ/pICIM=
 github.com/hashicorp/consul/api v1.26.1/go.mod h1:B4sQTeaSO16NtynqrAdwOlahJ7IUDZM9cj2420xYL8A=
 github.com/hashicorp/consul/sdk v0.15.0 h1:2qK9nDrr4tiJKRoxPGhm6B7xJjLVIQqkjiab2M4aKjU=

--- a/internal/tests/integration/gitfs_test.go
+++ b/internal/tests/integration/gitfs_test.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"io/fs"
 	"os"
+	"path"
 	"path/filepath"
 	"runtime"
 	"strconv"
@@ -102,6 +103,9 @@ func TestGitFS_File(t *testing.T) {
 	tmpDir := setupGitFSTest(t)
 
 	repoPath := filepath.ToSlash(tmpDir.Join("repo"))
+	// on Windows the path will start with a volume, but we need a 'file:///'
+	// prefix for the URL to be properly interpreted
+	repoPath = path.Join("/", repoPath)
 
 	fsys, _ := gitfs.New(tests.MustURL("git+file://" + repoPath))
 	f, err := fsys.Open("config.json")


### PR DESCRIPTION
Related to https://github.com/hairyhenderson/gomplate/pull/1916

`gitfs` likely suffers from the same bug - this flips to a fork of go-git that has the fix cherry-picked. I'll switch back once the upstream PR is merged.