### PR TITLE
Correct reported file permissions to be read-only

### DIFF
--- a/awssmfs/awssm.go
+++ b/awssmfs/awssm.go
@@ -355,7 +355,7 @@ func (f *awssmFile) getSecret() error {
 	}
 
 	// populate fi
-	f.fi = internal.FileInfo(f.name, seclen, 0o644, *modTime, "")
+	f.fi = internal.FileInfo(f.name, seclen, 0o444, *modTime, "")
 
 	return nil
 }

--- a/awssmpfs/awssmp.go
+++ b/awssmpfs/awssmp.go
@@ -360,7 +360,7 @@ func (f *awssmpFile) getParameter() error {
 	}
 
 	// populate fi
-	f.fi = internal.FileInfo(f.name, n, 0o644, *modTime, contentType)
+	f.fi = internal.FileInfo(f.name, n, 0o444, *modTime, contentType)
 
 	return nil
 }

--- a/blobfs/blob.go
+++ b/blobfs/blob.go
@@ -355,12 +355,12 @@ func (f *blobFile) Stat() (fs.FileInfo, error) {
 		return nil, err
 	}
 
-	mode := fs.FileMode(0o644)
+	mode := fs.FileMode(0o444)
 
 	azResp := azblobblob.GetPropertiesResponse{}
 	if out.As(&azResp) && *azResp.ContentType == "" {
 		// this is likely a directory
-		mode = fs.ModeDir
+		mode |= fs.ModeDir | 0o111
 	}
 
 	if fakeModTime != nil {
@@ -429,9 +429,9 @@ func (f *blobFile) ReadDir(n int) ([]fs.DirEntry, error) {
 			return nil, err
 		}
 
-		mode := fs.FileMode(0o644)
+		mode := fs.FileMode(0o444)
 		if obj.IsDir {
-			mode = fs.ModeDir
+			mode |= fs.ModeDir | 0o111
 		}
 
 		// container.BlobItem for objects, container.BlobPrefix for "directories"

--- a/blobfs/blob_test.go
+++ b/blobfs/blob_test.go
@@ -235,7 +235,7 @@ func TestBlobFS_ReadDir(t *testing.T) {
 
 	fi, err = f.Stat()
 	assert.NoError(t, err)
-	assert.Equal(t, fs.FileMode(0o644), fi.Mode())
+	assert.Equal(t, fs.FileMode(0o444), fi.Mode())
 }
 
 func TestBlobFS_CleanCdkURL(t *testing.T) {

--- a/consulfs/consul.go
+++ b/consulfs/consul.go
@@ -278,7 +278,7 @@ func (f *consulFile) get() error {
 	}
 
 	f.fi = internal.FileInfo(name, int64(len(kvPair.Value)),
-		0o644, time.Time{}, "",
+		0o444, time.Time{}, "",
 	)
 
 	f.body = io.NopCloser(bytes.NewReader(kvPair.Value))

--- a/consulfs/consul_test.go
+++ b/consulfs/consul_test.go
@@ -267,9 +267,9 @@ func TestReadDirFS(t *testing.T) {
 	assert.NoError(t, err)
 
 	des := []fs.DirEntry{
-		internal.FileInfo("bar", 3, 0o644, time.Time{}, "").(fs.DirEntry),
+		internal.FileInfo("bar", 3, 0o444, time.Time{}, "").(fs.DirEntry),
 		internal.DirInfo("bazDir", time.Time{}).(fs.DirEntry),
-		internal.FileInfo("foo", 3, 0o644, time.Time{}, "").(fs.DirEntry),
+		internal.FileInfo("foo", 3, 0o444, time.Time{}, "").(fs.DirEntry),
 	}
 	assert.EqualValues(t, des, de)
 
@@ -282,9 +282,9 @@ func TestReadDirFS(t *testing.T) {
 	assert.NoError(t, err)
 
 	des = []fs.DirEntry{
-		internal.FileInfo("bar", 3, 0o644, time.Time{}, "").(fs.DirEntry),
+		internal.FileInfo("bar", 3, 0o444, time.Time{}, "").(fs.DirEntry),
 		internal.DirInfo("bazDir", time.Time{}).(fs.DirEntry),
-		internal.FileInfo("foo", 3, 0o644, time.Time{}, "").(fs.DirEntry),
+		internal.FileInfo("foo", 3, 0o444, time.Time{}, "").(fs.DirEntry),
 	}
 	assert.EqualValues(t, des, de)
 }
@@ -310,7 +310,7 @@ func TestReadDirN(t *testing.T) {
 	assert.NoError(t, err)
 
 	des := []fs.DirEntry{
-		internal.FileInfo("bar", 3, 0o644, time.Time{}, "").(fs.DirEntry),
+		internal.FileInfo("bar", 3, 0o444, time.Time{}, "").(fs.DirEntry),
 	}
 	assert.EqualValues(t, des, de)
 
@@ -319,7 +319,7 @@ func TestReadDirN(t *testing.T) {
 
 	des = []fs.DirEntry{
 		internal.DirInfo("bazDir", time.Time{}).(fs.DirEntry),
-		internal.FileInfo("foo", 3, 0o644, time.Time{}, "").(fs.DirEntry),
+		internal.FileInfo("foo", 3, 0o444, time.Time{}, "").(fs.DirEntry),
 	}
 	assert.EqualValues(t, des, de)
 

--- a/examples/fscli/main_test.go
+++ b/examples/fscli/main_test.go
@@ -22,31 +22,31 @@ func TestLs(t *testing.T) {
 	mtime := time.Unix(0, 0).UTC()
 
 	fsys = fstest.MapFS{
-		"a": {ModTime: mtime, Mode: 0o644, Data: []byte("a")},
+		"a": {ModTime: mtime, Mode: 0o444, Data: []byte("a")},
 		"b": {
 			ModTime: mtime.AddDate(1, 1, 1).Add(12 * time.Hour),
-			Mode:    0o750, Data: bytes.Repeat([]byte("b"), 512),
+			Mode:    0o550, Data: bytes.Repeat([]byte("b"), 512),
 		},
-		"c":        {ModTime: mtime, Mode: 0o600, Data: bytes.Repeat([]byte("c"), 2560)},
-		"emptydir": {ModTime: mtime, Mode: 0o755 | fs.ModeDir},
-		"dir":      {ModTime: mtime, Mode: 0o755 | fs.ModeDir},
-		"dir/a":    {ModTime: mtime, Mode: 0o644, Data: []byte("aa")},
-		"dir/b":    {ModTime: mtime, Mode: 0o644, Data: []byte("bb")},
+		"c":        {ModTime: mtime, Mode: 0o400, Data: bytes.Repeat([]byte("c"), 2560)},
+		"emptydir": {ModTime: mtime, Mode: 0o555 | fs.ModeDir},
+		"dir":      {ModTime: mtime, Mode: 0o555 | fs.ModeDir},
+		"dir/a":    {ModTime: mtime, Mode: 0o444, Data: []byte("aa")},
+		"dir/b":    {ModTime: mtime, Mode: 0o444, Data: []byte("bb")},
 	}
 
 	err = ls(fsys, ".", w)
 	assert.NoError(t, err)
-	assert.Equal(t, ` -rw-r--r--     1B 1970-01-01 00:00 a
- -rwxr-x---   512B 1971-02-02 12:00 b
- -rw------- 2.5KiB 1970-01-01 00:00 c
- drwxr-xr-x        1970-01-01 00:00 dir
- drwxr-xr-x        1970-01-01 00:00 emptydir
+	assert.Equal(t, ` -r--r--r--     1B 1970-01-01 00:00 a
+ -r-xr-x---   512B 1971-02-02 12:00 b
+ -r-------- 2.5KiB 1970-01-01 00:00 c
+ dr-xr-xr-x        1970-01-01 00:00 dir
+ dr-xr-xr-x        1970-01-01 00:00 emptydir
 `, w.String())
 }
 
 func TestCat(t *testing.T) {
 	fsys := fstest.MapFS{
-		"a": {ModTime: time.Unix(0, 0).UTC(), Mode: 0o644, Data: []byte("aaa")},
+		"a": {ModTime: time.Unix(0, 0).UTC(), Mode: 0o444, Data: []byte("aaa")},
 	}
 
 	w := &bytes.Buffer{}
@@ -58,7 +58,7 @@ func TestCat(t *testing.T) {
 
 func TestStat(t *testing.T) {
 	fsys := fstest.MapFS{
-		"a.txt": {ModTime: time.Unix(0, 0).UTC(), Mode: 0o644, Data: []byte("aaa")},
+		"a.txt": {ModTime: time.Unix(0, 0).UTC(), Mode: 0o444, Data: []byte("aaa")},
 	}
 
 	w := &bytes.Buffer{}
@@ -68,7 +68,7 @@ func TestStat(t *testing.T) {
 	assert.Equal(t, `a.txt:
 	Size:         3B
 	Modified:     1970-01-01T00:00:00Z
-	Mode:         -rw-r--r--
+	Mode:         -r--r--r--
 	Content-Type: text/plain; charset=utf-8
 `, w.String())
 }

--- a/httpfs/http.go
+++ b/httpfs/http.go
@@ -170,7 +170,7 @@ func (f *httpFile) request(method string) (io.ReadCloser, error) {
 		modTime, _ = http.ParseTime(mod)
 	}
 
-	f.fi = internal.FileInfo(f.name, resp.ContentLength, 0o644, modTime, resp.Header.Get("Content-Type"))
+	f.fi = internal.FileInfo(f.name, resp.ContentLength, 0o444, modTime, resp.Header.Get("Content-Type"))
 
 	if resp.StatusCode == 0 || resp.StatusCode >= 400 {
 		return nil, fmt.Errorf("http GET failed with status %d", resp.StatusCode)

--- a/internal/types.go
+++ b/internal/types.go
@@ -25,7 +25,7 @@ func FileInfo(name string, size int64, mode fs.FileMode, modTime time.Time, cont
 // DirInfo creates a fs.FileInfo for a directory with the given name. Use
 // FileInfo to set other values.
 func DirInfo(name string, modTime time.Time) fs.FileInfo {
-	return FileInfo(name, 0, fs.ModeDir, modTime, "")
+	return FileInfo(name, 0, fs.ModeDir|0o555, modTime, "")
 }
 
 type staticFileInfo struct {

--- a/vaultfs/vault.go
+++ b/vaultfs/vault.go
@@ -440,7 +440,7 @@ func (f *vaultFile) Stat() (fs.FileInfo, error) {
 	return internal.FileInfo(
 		strings.TrimSuffix(path.Base(f.name), "/"),
 		int64(len(b)),
-		0o644,
+		0o444,
 		modTime,
 		"application/json",
 	), nil

--- a/vaultfs/vault_test.go
+++ b/vaultfs/vault_test.go
@@ -251,9 +251,9 @@ func TestReadDirFS(t *testing.T) {
 	assert.NoError(t, err)
 
 	des := []fs.DirEntry{
-		internal.FileInfo("bar", 15, 0o644, time.Time{}, "application/json").(fs.DirEntry),
+		internal.FileInfo("bar", 15, 0o444, time.Time{}, "application/json").(fs.DirEntry),
 		internal.DirInfo("bazDir", time.Time{}).(fs.DirEntry),
-		internal.FileInfo("foo", 15, 0o644, time.Time{}, "application/json").(fs.DirEntry),
+		internal.FileInfo("foo", 15, 0o444, time.Time{}, "application/json").(fs.DirEntry),
 	}
 	assert.EqualValues(t, des, de)
 
@@ -264,9 +264,9 @@ func TestReadDirFS(t *testing.T) {
 	assert.NoError(t, err)
 
 	des = []fs.DirEntry{
-		internal.FileInfo("bar", 15, 0o644, time.Time{}, "application/json").(fs.DirEntry),
+		internal.FileInfo("bar", 15, 0o444, time.Time{}, "application/json").(fs.DirEntry),
 		internal.DirInfo("bazDir", time.Time{}).(fs.DirEntry),
-		internal.FileInfo("foo", 15, 0o644, time.Time{}, "application/json").(fs.DirEntry),
+		internal.FileInfo("foo", 15, 0o444, time.Time{}, "application/json").(fs.DirEntry),
 	}
 	assert.EqualValues(t, des, de)
 }
@@ -290,7 +290,7 @@ func TestReadDirN(t *testing.T) {
 	assert.NoError(t, err)
 
 	des := []fs.DirEntry{
-		internal.FileInfo("foo", 15, 0o644, time.Time{}, "application/json").(fs.DirEntry),
+		internal.FileInfo("foo", 15, 0o444, time.Time{}, "application/json").(fs.DirEntry),
 	}
 	assert.EqualValues(t, des, de)
 
@@ -298,7 +298,7 @@ func TestReadDirN(t *testing.T) {
 	assert.NoError(t, err)
 
 	des = []fs.DirEntry{
-		internal.FileInfo("bar", 15, 0o644, time.Time{}, "application/json").(fs.DirEntry),
+		internal.FileInfo("bar", 15, 0o444, time.Time{}, "application/json").(fs.DirEntry),
 		internal.DirInfo("bazDir", time.Time{}).(fs.DirEntry),
 	}
 	assert.EqualValues(t, des, de)


### PR DESCRIPTION
Found this during #472 - before:

```console
$ bin/fscli_darwin-amd64 -base-url=aws+imds://127.0.0.1:1338/meta-data/network ls
 d---------  0001-01-01 00:00 interfaces
```

note the file permissions make the directory appear to be non-readable, while in reality it is.

After:

```console
$ bin/fscli_darwin-amd64 -base-url=aws+imds://127.0.0.1:1338/meta-data/network ls
 dr-xr-xr-x  0001-01-01 00:00 interfaces
```

Files are also corrected to be marked read-only (`r--r--r--`/`0o444`).