### PR TITLE
vaultfs: auth improvements

### DIFF
--- a/vaultfs/auth.go
+++ b/vaultfs/auth.go
@@ -39,7 +39,7 @@ type withAPIAuthMethoder interface {
 // an optional interface that auth methods may implement to override the regular
 // token revocation
 type authLogouter interface {
-	Logout(client *api.Client)
+	Logout(ctx context.Context, client *api.Client)
 }
 
 // AuthMethod is an authentication method that vaultfs can use to acquire a

--- a/vaultfs/vault_test.go
+++ b/vaultfs/vault_test.go
@@ -402,7 +402,7 @@ func (m *spyAuthMethod) Login(_ context.Context, client *api.Client) (*api.Secre
 }
 
 // make sure logout functionality works
-func (m *spyAuthMethod) Logout(client *api.Client) {
+func (m *spyAuthMethod) Logout(_ context.Context, client *api.Client) {
 	client.ClearToken()
 }
 

--- a/vaultfs/vaultauth/env_test.go
+++ b/vaultfs/vaultauth/env_test.go
@@ -23,7 +23,7 @@ func TestEnvAuthLogin(t *testing.T) {
 	s, err := m.Login(ctx, v)
 	require.NoError(t, err)
 	assert.Equal(t, "foo", s.Auth.ClientToken)
-	assert.NotNil(t, m.(*envAuthMethod).chosen)
+	assert.NotNil(t, m.(*compositeAuthMethod).chosen)
 }
 
 func fakeVaultServer(t *testing.T) *api.Client {

--- a/vaultfs/vaultauth/token.go
+++ b/vaultfs/vaultauth/token.go
@@ -58,7 +58,7 @@ func (m *tokenAuthMethod) Login(_ context.Context, _ *api.Client) (*api.Secret, 
 
 // Logout implements the vaultfs.authLogouter interface because we need to keep
 // the token unmanaged.
-func (m *tokenAuthMethod) Logout(client *api.Client) {
+func (m *tokenAuthMethod) Logout(_ context.Context, client *api.Client) {
 	// just clear the client's token, nothing else needs to be done here
 	client.ClearToken()
 }


### PR DESCRIPTION
During https://github.com/hairyhenderson/gomplate/pull/1336 I realized that the `vaultauth.EnvAuthMethod` causes tokens to be revoked, when they shouldn't be, because it wasn't implementing the `authLogouter` interface.

I've fixed this up, and altered that interface to be able to pass a context (it's only used here, so that's safe).

This also tweaks the error handling when a GET fails and falls back to LIST - if both fail, the first error is returned since that might make a bit more sense.

This also exports `vaultauth.CompositeAuthMethod` for easier auth method composition.