### PR TITLE
Handle possibility of nil context, clients, or headers

### DIFF
--- a/awsimdsfs/awsimdsfs.go
+++ b/awsimdsfs/awsimdsfs.go
@@ -89,22 +89,34 @@ func (f awsimdsFS) URL() string {
 	return f.base.String()
 }
 
-func (f awsimdsFS) WithContext(ctx context.Context) fs.FS {
-	fsys := f
+func (f *awsimdsFS) WithContext(ctx context.Context) fs.FS {
+	if ctx == nil {
+		return f
+	}
+
+	fsys := *f
 	fsys.ctx = ctx
 
 	return &fsys
 }
 
-func (f awsimdsFS) WithHTTPClient(client *http.Client) fs.FS {
-	fsys := f
+func (f *awsimdsFS) WithHTTPClient(client *http.Client) fs.FS {
+	if client == nil {
+		return f
+	}
+
+	fsys := *f
 	fsys.httpclient = client
 
 	return &fsys
 }
 
-func (f awsimdsFS) WithIMDSClient(imdsclient IMDSClient) fs.FS {
-	fsys := f
+func (f *awsimdsFS) WithIMDSClient(imdsclient IMDSClient) fs.FS {
+	if imdsclient == nil {
+		return f
+	}
+
+	fsys := *f
 	fsys.imdsclient = imdsclient
 
 	return &fsys

--- a/awssmfs/awssm.go
+++ b/awssmfs/awssm.go
@@ -92,22 +92,34 @@ func (f awssmFS) URL() string {
 	return f.base.String()
 }
 
-func (f awssmFS) WithContext(ctx context.Context) fs.FS {
-	fsys := f
+func (f *awssmFS) WithContext(ctx context.Context) fs.FS {
+	if ctx == nil {
+		return f
+	}
+
+	fsys := *f
 	fsys.ctx = ctx
 
 	return &fsys
 }
 
-func (f awssmFS) WithHTTPClient(client *http.Client) fs.FS {
-	fsys := f
+func (f *awssmFS) WithHTTPClient(client *http.Client) fs.FS {
+	if client == nil {
+		return f
+	}
+
+	fsys := *f
 	fsys.httpclient = client
 
 	return &fsys
 }
 
-func (f awssmFS) WithSMClient(smclient SecretsManagerClient) fs.FS {
-	fsys := f
+func (f *awssmFS) WithSMClient(smclient SecretsManagerClient) fs.FS {
+	if smclient == nil {
+		return f
+	}
+
+	fsys := *f
 	fsys.smclient = smclient
 
 	return &fsys

--- a/awssmpfs/awssmp.go
+++ b/awssmpfs/awssmp.go
@@ -97,22 +97,34 @@ func (f awssmpFS) URL() string {
 	return f.base.String()
 }
 
-func (f awssmpFS) WithContext(ctx context.Context) fs.FS {
-	fsys := f
+func (f *awssmpFS) WithContext(ctx context.Context) fs.FS {
+	if ctx == nil {
+		return f
+	}
+
+	fsys := *f
 	fsys.ctx = ctx
 
 	return &fsys
 }
 
-func (f awssmpFS) WithHTTPClient(client *http.Client) fs.FS {
-	fsys := f
+func (f *awssmpFS) WithHTTPClient(client *http.Client) fs.FS {
+	if client == nil {
+		return f
+	}
+
+	fsys := *f
 	fsys.httpclient = client
 
 	return &fsys
 }
 
-func (f awssmpFS) WithClient(ssmclient SSMClient) fs.FS {
-	fsys := f
+func (f *awssmpFS) WithClient(ssmclient SSMClient) fs.FS {
+	if ssmclient == nil {
+		return f
+	}
+
+	fsys := *f
 	fsys.ssmclient = ssmclient
 
 	return &fsys

--- a/blobfs/blob.go
+++ b/blobfs/blob.go
@@ -83,15 +83,23 @@ func (f blobFS) URL() string {
 	return f.base.String()
 }
 
-func (f blobFS) WithContext(ctx context.Context) fs.FS {
-	fsys := f
+func (f *blobFS) WithContext(ctx context.Context) fs.FS {
+	if ctx == nil {
+		return f
+	}
+
+	fsys := *f
 	fsys.ctx = ctx
 
 	return &fsys
 }
 
-func (f blobFS) WithHTTPClient(client *http.Client) fs.FS {
-	fsys := f
+func (f *blobFS) WithHTTPClient(client *http.Client) fs.FS {
+	if client == nil {
+		return f
+	}
+
+	fsys := *f
 	fsys.hclient = client
 
 	return &fsys

--- a/consulfs/consul.go
+++ b/consulfs/consul.go
@@ -70,15 +70,23 @@ func (f consulFS) URL() string {
 	return f.base.String()
 }
 
-func (f consulFS) WithContext(ctx context.Context) fs.FS {
-	fsys := f
+func (f *consulFS) WithContext(ctx context.Context) fs.FS {
+	if ctx == nil {
+		return f
+	}
+
+	fsys := *f
 	fsys.ctx = ctx
 
 	return &fsys
 }
 
-func (f consulFS) WithHeader(header http.Header) fs.FS {
-	fsys := f
+func (f *consulFS) WithHeader(header http.Header) fs.FS {
+	if header == nil {
+		return f
+	}
+
+	fsys := *f
 	fsys.header = header
 
 	if fsys.client != nil {
@@ -92,8 +100,12 @@ func (f consulFS) WithHeader(header http.Header) fs.FS {
 	return &fsys
 }
 
-func (f consulFS) WithConfig(config *api.Config) fs.FS {
-	fsys := f
+func (f *consulFS) WithConfig(config *api.Config) fs.FS {
+	if config == nil {
+		return f
+	}
+
+	fsys := *f
 	fsys.client = nil
 	fsys.config = config
 

--- a/gitfs/git.go
+++ b/gitfs/git.go
@@ -78,15 +78,23 @@ func (f gitFS) URL() string {
 	return f.repo.String()
 }
 
-func (f gitFS) WithAuthenticator(auth Authenticator) fs.FS {
-	fsys := f
+func (f *gitFS) WithAuthenticator(auth Authenticator) fs.FS {
+	if auth == nil {
+		return f
+	}
+
+	fsys := *f
 	fsys.auth = auth
 
 	return &fsys
 }
 
-func (f gitFS) WithContext(ctx context.Context) fs.FS {
-	fsys := f
+func (f *gitFS) WithContext(ctx context.Context) fs.FS {
+	if ctx == nil {
+		return f
+	}
+
+	fsys := *f
 	fsys.ctx = ctx
 
 	return &fsys

--- a/httpfs/http.go
+++ b/httpfs/http.go
@@ -54,19 +54,27 @@ func (f httpFS) URL() string {
 	return f.base.String()
 }
 
-func (f httpFS) WithContext(ctx context.Context) fs.FS {
-	fsys := f
+func (f *httpFS) WithContext(ctx context.Context) fs.FS {
+	if ctx == nil {
+		return f
+	}
+
+	fsys := *f
 	fsys.ctx = ctx
 
 	return &fsys
 }
 
-func (f httpFS) WithHeader(headers http.Header) fs.FS {
-	fsys := f
+func (f *httpFS) WithHeader(headers http.Header) fs.FS {
+	if headers == nil {
+		return f
+	}
+
+	fsys := *f
 	if len(fsys.headers) == 0 {
 		fsys.headers = headers
 	} else {
-		for k, vs := range fsys.headers {
+		for k, vs := range headers {
 			for _, v := range vs {
 				fsys.headers.Add(k, v)
 			}
@@ -76,8 +84,12 @@ func (f httpFS) WithHeader(headers http.Header) fs.FS {
 	return &fsys
 }
 
-func (f httpFS) WithHTTPClient(client *http.Client) fs.FS {
-	fsys := f
+func (f *httpFS) WithHTTPClient(client *http.Client) fs.FS {
+	if client == nil {
+		return f
+	}
+
+	fsys := *f
 	fsys.client = client
 
 	return &fsys

--- a/vaultfs/vault.go
+++ b/vaultfs/vault.go
@@ -120,15 +120,23 @@ func (f vaultFS) URL() string {
 	return f.base.String()
 }
 
-func (f vaultFS) WithContext(ctx context.Context) fs.FS {
-	fsys := f
+func (f *vaultFS) WithContext(ctx context.Context) fs.FS {
+	if ctx == nil {
+		return f
+	}
+
+	fsys := *f
 	fsys.ctx = ctx
 
 	return &fsys
 }
 
-func (f vaultFS) WithHeader(headers http.Header) fs.FS {
-	fsys := f
+func (f *vaultFS) WithHeader(headers http.Header) fs.FS {
+	if headers == nil {
+		return f
+	}
+
+	fsys := *f
 
 	for k, vs := range headers {
 		for _, v := range vs {


### PR DESCRIPTION
If I call `WithHTTPClient(nil)` the client will be set to nil, rather than falling back to the default client which was originally set. This fixes that!