### PR TITLE
fix(perf): Replace slower fmt.Sprint(f) calls with faster alternatives

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -70,8 +70,7 @@ linters:
     - nolintlint
     - nosprintfhostport
     ## - paralleltest
-    # fmt.Errorf() with no args is abou5 200x slower than errors.New()
-    ##- perfsprint
+    - perfsprint
     - prealloc
     - predeclared
     - promlinter

--- a/awssmpfs/awssmp.go
+++ b/awssmpfs/awssmp.go
@@ -145,7 +145,7 @@ func (f *awssmpFS) getClient(ctx context.Context) (SSMClient, error) {
 		customResolver := aws.EndpointResolverWithOptionsFunc(func(_, _ string, _ ...interface{}) (aws.Endpoint, error) {
 			return aws.Endpoint{
 				PartitionID:   "aws",
-				URL:           fmt.Sprintf("http://%s", f.base.Host),
+				URL:           "http://" + f.base.Host,
 				SigningRegion: "us-east-1",
 			}, nil
 		})

--- a/consulfs/consul.go
+++ b/consulfs/consul.go
@@ -34,7 +34,7 @@ type consulFS struct {
 // New creates a filesystem for the Consul KV endpoint rooted at u.
 func New(u *url.URL) (fs.FS, error) {
 	if u == nil {
-		return nil, fmt.Errorf("url must not be nil")
+		return nil, errors.New("url must not be nil")
 	}
 
 	if u.Path == "" {

--- a/gitfs/auth.go
+++ b/gitfs/auth.go
@@ -2,6 +2,7 @@ package gitfs
 
 import (
 	"encoding/base64"
+	"errors"
 	"fmt"
 	"io/fs"
 	"net/url"
@@ -184,7 +185,7 @@ func (a *tokenAuthenticator) Authenticate(u *url.URL) (AuthMethod, error) {
 	}
 
 	if token == "" {
-		return nil, fmt.Errorf("token may not be empty for token authentication")
+		return nil, errors.New("token may not be empty for token authentication")
 	}
 
 	return &githttp.TokenAuth{Token: token}, nil
@@ -241,7 +242,7 @@ func (a *publicKeyAuthenticator) Authenticate(u *url.URL) (AuthMethod, error) {
 	}
 
 	if len(k) == 0 {
-		return nil, fmt.Errorf("private key may not be empty for public key authentication")
+		return nil, errors.New("private key may not be empty for public key authentication")
 	}
 
 	return ssh.NewPublicKeys(username, k, a.keyPass)

--- a/gitfs/git.go
+++ b/gitfs/git.go
@@ -186,7 +186,7 @@ func (f *gitFS) gitClone(ctx context.Context, repoURL url.URL, depth int) (billy
 	u := repoURL
 
 	if f.auth == nil {
-		return nil, nil, fmt.Errorf("clone: no auth method provided")
+		return nil, nil, errors.New("clone: no auth method provided")
 	}
 
 	authMethod, err := f.auth.Authenticate(&u)
@@ -273,7 +273,7 @@ func (f *gitFS) refFromRemoteHead(ctx context.Context, u *url.URL) (plumbing.Ref
 
 	headRef, ok := refs["HEAD"]
 	if !ok {
-		return "", fmt.Errorf("no HEAD ref found")
+		return "", errors.New("no HEAD ref found")
 	}
 
 	return headRef.Target(), nil

--- a/gitfs/git_test.go
+++ b/gitfs/git_test.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"strconv"
 	"strings"
 	"testing"
 	"testing/fstest"
@@ -84,7 +85,7 @@ func BenchmarkSplitRepoPath(b *testing.B) {
 	for i, d := range data {
 		b.ResetTimer()
 
-		b.Run(fmt.Sprintf("%d", i), func(b *testing.B) {
+		b.Run(strconv.Itoa(i), func(b *testing.B) {
 			for i := 0; i < b.N; i++ {
 				splitRepoPath(d)
 			}

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/hairyhenderson/go-fsimpl
 
-go 1.22.1
+go 1.22.3
 
 require (
 	github.com/Azure/azure-sdk-for-go/sdk/storage/azblob v1.3.2

--- a/vaultfs/auth.go
+++ b/vaultfs/auth.go
@@ -2,6 +2,7 @@ package vaultfs
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io/fs"
 	"os"
@@ -215,12 +216,12 @@ type appRoleAuthMethod struct {
 func (m *appRoleAuthMethod) Login(ctx context.Context, client *api.Client) error {
 	roleID := findValue(m.roleID, "VAULT_ROLE_ID", "", m.fsys)
 	if roleID == "" {
-		return fmt.Errorf("approle auth failure: no role_id provided")
+		return errors.New("approle auth failure: no role_id provided")
 	}
 
 	secretID := findValue(m.secretID, "VAULT_SECRET_ID", "", m.fsys)
 	if secretID == "" {
-		return fmt.Errorf("approle auth failure: no secret_id provided")
+		return errors.New("approle auth failure: no secret_id provided")
 	}
 
 	mount := findValue(m.mount, "VAULT_AUTH_APPROLE_MOUNT", "approle", m.fsys)
@@ -269,7 +270,7 @@ type gitHubAuthMethod struct {
 func (m *gitHubAuthMethod) Login(ctx context.Context, client *api.Client) error {
 	ghtoken := findValue(m.ghtoken, "VAULT_AUTH_GITHUB_TOKEN", "", m.fsys)
 	if ghtoken == "" {
-		return fmt.Errorf("github auth failure: no username provided")
+		return errors.New("github auth failure: no username provided")
 	}
 
 	mount := findValue(m.mount, "VAULT_AUTH_GITHUB_MOUNT", "github", m.fsys)
@@ -319,12 +320,12 @@ type userPassAuthMethod struct {
 func (m *userPassAuthMethod) Login(ctx context.Context, client *api.Client) error {
 	username := findValue(m.username, "VAULT_AUTH_USERNAME", "", m.fsys)
 	if username == "" {
-		return fmt.Errorf("userpass auth failure: no username provided")
+		return errors.New("userpass auth failure: no username provided")
 	}
 
 	password := findValue(m.password, "VAULT_AUTH_PASSWORD", "", m.fsys)
 	if password == "" {
-		return fmt.Errorf("userpass auth failure: no password provided")
+		return errors.New("userpass auth failure: no password provided")
 	}
 
 	mount := findValue(m.mount, "VAULT_AUTH_USERPASS_MOUNT", "userpass", m.fsys)

--- a/vaultfs/vault.go
+++ b/vaultfs/vault.go
@@ -41,7 +41,7 @@ type vaultFS struct {
 //   - [fsimpl.WithHeaderFS] (inject custom HTTP headers)
 func New(u *url.URL) (fs.FS, error) {
 	if u == nil {
-		return nil, fmt.Errorf("url must not be nil")
+		return nil, errors.New("url must not be nil")
 	}
 
 	if u.Path == "" {
@@ -440,7 +440,7 @@ func (f *vaultFile) Stat() (fs.FileInfo, error) {
 
 	if secret == nil || secret.Data == nil {
 		return nil, &fs.PathError{
-			Op: "stat", Path: f.name, Err: fmt.Errorf("malformed secret"),
+			Op: "stat", Path: f.name, Err: errors.New("malformed secret"),
 		}
 	}
 
@@ -486,7 +486,7 @@ func (f *vaultFile) list() ([]string, error) {
 
 	keys, ok := s.Data["keys"]
 	if !ok {
-		return nil, fmt.Errorf("keys missing from vault LIST response")
+		return nil, errors.New("keys missing from vault LIST response")
 	}
 
 	k, ok := keys.([]interface{})

--- a/vaultfs/vaultauth/github.go
+++ b/vaultfs/vaultauth/github.go
@@ -2,6 +2,7 @@ package vaultauth
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"io/fs"
@@ -59,19 +60,19 @@ type GitHubToken struct {
 //nolint:gocyclo
 func (token *GitHubToken) validate() error {
 	if token == nil {
-		return fmt.Errorf("github auth method requires a token")
+		return errors.New("github auth method requires a token")
 	}
 
 	if token.FromFile == "" && token.FromEnv == "" && token.FromString == "" {
-		return fmt.Errorf("token for GitHub auth must be provided with a source file, environment variable, or plaintext string")
+		return errors.New("token for GitHub auth must be provided with a source file, environment variable, or plaintext string")
 	}
 
 	if token.FromFile != "" && (token.FromEnv != "" || token.FromString != "") {
-		return fmt.Errorf("only one source for the token should be specified")
+		return errors.New("only one source for the token should be specified")
 	}
 
 	if token.FromEnv != "" && (token.FromFile != "" || token.FromString != "") {
-		return fmt.Errorf("only one source for the token should be specified")
+		return errors.New("only one source for the token should be specified")
 	}
 
 	return nil


### PR DESCRIPTION
Applying recommendations from the `perfsprint` linter - for example, `fmt.Errorf("...")` is about 200x slower than `errors.New("...")`!