### PR TITLE
fix(httpfs/consulfs): base URL query parameters weren't preserved

### DIFF
--- a/consulfs/consul.go
+++ b/consulfs/consul.go
@@ -182,7 +182,7 @@ func (f *consulFS) Open(name string) (fs.File, error) {
 		return nil, &fs.PathError{Op: "open", Path: name, Err: fs.ErrInvalid}
 	}
 
-	u, err := subURL(f.base, name)
+	u, err := internal.SubURL(f.base, name)
 	if err != nil {
 		return nil, err
 	}
@@ -209,7 +209,7 @@ func (f *consulFS) ReadFile(name string) ([]byte, error) {
 		}
 	}
 
-	u, err := subURL(f.base, name)
+	u, err := internal.SubURL(f.base, name)
 	if err != nil {
 		return nil, err
 	}
@@ -227,15 +227,6 @@ func (f *consulFS) ReadFile(name string) ([]byte, error) {
 	}
 
 	return kvPair.Value, nil
-}
-
-func subURL(base *url.URL, name string) (*url.URL, error) {
-	rel, err := url.Parse(name)
-	if err != nil {
-		return nil, err
-	}
-
-	return base.ResolveReference(rel), nil
 }
 
 type consulFile struct {
@@ -398,7 +389,7 @@ func (f *consulFile) childFile(childName string) *consulFile {
 		parent.Path += "/"
 	}
 
-	childURL, _ := subURL(&parent, childName)
+	childURL, _ := internal.SubURL(&parent, childName)
 
 	cf := &consulFile{
 		ctx:       f.ctx,

--- a/consulfs/consul_test.go
+++ b/consulfs/consul_test.go
@@ -365,18 +365,6 @@ func TestReadDirN(t *testing.T) {
 	assert.Len(t, de, 3)
 }
 
-func TestSubURL(t *testing.T) {
-	base := tests.MustURL("https://example.com/dir/")
-	sub, err := subURL(base, "sub")
-	assert.NoError(t, err)
-	assert.Equal(t, "https://example.com/dir/sub", sub.String())
-
-	base = tests.MustURL("consul:///dir/")
-	sub, err = subURL(base, "sub/foo?param=foo")
-	assert.NoError(t, err)
-	assert.Equal(t, "consul:///dir/sub/foo?param=foo", sub.String())
-}
-
 func TestStat(t *testing.T) {
 	config := fakeConsulServer(t)
 

--- a/httpfs/http.go
+++ b/httpfs/http.go
@@ -104,7 +104,7 @@ func (f httpFS) Open(name string) (fs.File, error) {
 		}
 	}
 
-	u, err := f.subURL(name)
+	u, err := internal.SubURL(f.base, name)
 	if err != nil {
 		return nil, err
 	}
@@ -136,7 +136,7 @@ func (f httpFS) ReadFile(name string) ([]byte, error) {
 func (f httpFS) Sub(name string) (fs.FS, error) {
 	fsys := f
 
-	u, err := f.subURL(name)
+	u, err := internal.SubURL(f.base, name)
 	if err != nil {
 		return nil, err
 	}
@@ -144,15 +144,6 @@ func (f httpFS) Sub(name string) (fs.FS, error) {
 	fsys.base = u
 
 	return &fsys, nil
-}
-
-func (f *httpFS) subURL(name string) (*url.URL, error) {
-	rel, err := url.Parse(name)
-	if err != nil {
-		return nil, err
-	}
-
-	return f.base.ResolveReference(rel), nil
 }
 
 type httpFile struct {

--- a/internal/url.go
+++ b/internal/url.go
@@ -1,0 +1,26 @@
+package internal
+
+import "net/url"
+
+func SubURL(base *url.URL, name string) (*url.URL, error) {
+	rel, err := url.Parse(name)
+	if err != nil {
+		return nil, err
+	}
+
+	u := base.ResolveReference(rel)
+
+	// also merge query params
+	if base.RawQuery != "" {
+		bq := base.Query()
+		rq := rel.Query()
+
+		for k := range rq {
+			bq.Set(k, rq.Get(k))
+		}
+
+		u.RawQuery = bq.Encode()
+	}
+
+	return u, nil
+}

--- a/internal/url_test.go
+++ b/internal/url_test.go
@@ -1,0 +1,31 @@
+package internal
+
+import (
+	"testing"
+
+	"github.com/hairyhenderson/go-fsimpl/internal/tests"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSubURL(t *testing.T) {
+	base := tests.MustURL("https://example.com/dir/")
+	sub, err := SubURL(base, "sub")
+	assert.NoError(t, err)
+	assert.Equal(t, "https://example.com/dir/sub", sub.String())
+
+	base = tests.MustURL("consul:///dir/")
+	sub, err = SubURL(base, "sub/foo?param=foo")
+	assert.NoError(t, err)
+	assert.Equal(t, "consul:///dir/sub/foo?param=foo", sub.String())
+
+	base = tests.MustURL("vault:///dir/?param1=foo&param2=bar")
+	sub, err = SubURL(base, "sub/foo")
+	require.NoError(t, err)
+	assert.Equal(t, "vault:///dir/sub/foo?param1=foo&param2=bar", sub.String())
+
+	base = tests.MustURL("consul:///dir/?param1=foo&param2=bar")
+	sub, err = SubURL(base, "sub/foo?param3=baz")
+	require.NoError(t, err)
+	assert.Equal(t, "consul:///dir/sub/foo?param1=foo&param2=bar&param3=baz", sub.String())
+}

--- a/vaultfs/vault.go
+++ b/vaultfs/vault.go
@@ -159,7 +159,7 @@ func (f vaultFS) Open(name string) (fs.File, error) {
 		return nil, &fs.PathError{Op: "open", Path: name, Err: fs.ErrInvalid}
 	}
 
-	u, err := f.subURL(name)
+	u, err := internal.SubURL(f.base, name)
 	if err != nil {
 		return nil, err
 	}
@@ -191,29 +191,6 @@ func (f vaultFS) ReadFile(name string) ([]byte, error) {
 	}
 
 	return b, nil
-}
-
-func (f *vaultFS) subURL(name string) (*url.URL, error) {
-	rel, err := url.Parse(name)
-	if err != nil {
-		return nil, err
-	}
-
-	u := f.base.ResolveReference(rel)
-
-	// also merge query params
-	if f.base.RawQuery != "" {
-		bq := f.base.Query()
-		rq := rel.Query()
-
-		for k := range rq {
-			bq.Set(k, rq.Get(k))
-		}
-
-		u.RawQuery = bq.Encode()
-	}
-
-	return u, nil
 }
 
 // newVaultFile opens a vault file/dir for reading - if this file is not closed

--- a/vaultfs/vault_test.go
+++ b/vaultfs/vault_test.go
@@ -348,29 +348,6 @@ func TestReadDirN(t *testing.T) {
 	assert.Len(t, de, 3)
 }
 
-func TestSubURL(t *testing.T) {
-	fsys := &vaultFS{base: tests.MustURL("https://example.com/v1/secret/")}
-
-	sub, err := fsys.subURL("foo")
-	assert.NoError(t, err)
-	assert.Equal(t, "https://example.com/v1/secret/foo", sub.String())
-
-	fsys = &vaultFS{base: tests.MustURL("vault:///v1/secret/")}
-	sub, err = fsys.subURL("sub/foo?param=foo")
-	assert.NoError(t, err)
-	assert.Equal(t, "vault:///v1/secret/sub/foo?param=foo", sub.String())
-
-	fsys = &vaultFS{base: tests.MustURL("vault:///v1/secret/?param1=foo&param2=bar")}
-	sub, err = fsys.subURL("sub/foo")
-	assert.NoError(t, err)
-	assert.Equal(t, "vault:///v1/secret/sub/foo?param1=foo&param2=bar", sub.String())
-
-	fsys = &vaultFS{base: tests.MustURL("vault:///v1/secret/?param1=foo&param2=bar")}
-	sub, err = fsys.subURL("sub/foo?param3=baz")
-	assert.NoError(t, err)
-	assert.Equal(t, "vault:///v1/secret/sub/foo?param1=foo&param2=bar&param3=baz", sub.String())
-}
-
 func TestStat(t *testing.T) {
 	v := newRefCountedClient(fakeVaultServer(t))
 


### PR DESCRIPTION
Fixes a bug where query parameters on the base URL in https and consults weren't properly being used by file URLs.

This behaviour was already present on vaultfs, so I've just reused the same code.