### PR TITLE
ci: Run tests on 32-bit (386) as well

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,15 +12,18 @@ permissions:
 jobs:
   linux-build:
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        goarch: [ '386', 'amd64' ]
     container:
-      image: ghcr.io/hairyhenderson/gomplate-ci-build:latest
+      image: ghcr.io/hairyhenderson/gomplate-ci-build
     steps:
       - run: |
           git config --global user.email "bogus@example.com"
           git config --global user.name "Someone"
       - uses: actions/checkout@v4
-      - run: make test
-      - run: make test-race
+      - run: make test GOARCH=${{ matrix.goarch }}
   fscli-build:
     runs-on: ubuntu-latest
     strategy:

--- a/Makefile
+++ b/Makefile
@@ -20,11 +20,18 @@ else
 LINT_PROCS ?= $(shell nproc)
 endif
 
-test:
-	CGO_ENABLED=0 go test -coverprofile=c.out ./...
+# test with race detector on supported platforms
+# windows/amd64 is supported in theory, but in practice it requires a C compiler
+race_platforms := 'linux/amd64' 'darwin/amd64' 'darwin/arm64'
+ifeq (,$(findstring '$(GOOS)/$(GOARCH)',$(race_platforms)))
+export CGO_ENABLED=0
+TEST_ARGS=
+else
+TEST_ARGS=-race
+endif
 
-test-race:
-	go test -race -coverprofile=c.out ./...
+test:
+	go test $(TEST_ARGS) -coverprofile=c.out ./...
 
 bin/fscli_%v7$(call extension,$(GOOS)): $(shell find . -type f -name "*.go")
 	GOOS=$(shell echo $* | cut -f1 -d-) \

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/hairyhenderson/go-fsimpl
 
-go 1.22.3
+go 1.22.4
 
 require (
 	github.com/Azure/azure-sdk-for-go/sdk/storage/azblob v1.3.2


### PR DESCRIPTION
Related to https://github.com/hairyhenderson/gomplate/issues/2121 - there are some alignment bugs in go-fsimpl that went unnoticed. Testing on a 32-bit architecture in CI should help!