### PR TITLE
fix(vaultfs): Support KVv2 mounts that contain slashes

### DIFF
--- a/internal/tests/fakevault/fakevault.go
+++ b/internal/tests/fakevault/fakevault.go
@@ -1,0 +1,128 @@
+package fakevault
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+
+	"github.com/hashicorp/vault/api"
+	"github.com/stretchr/testify/assert"
+)
+
+func mountHandler(w http.ResponseWriter, _ *http.Request) {
+	mounts := map[string]interface{}{
+		"secret/": map[string]interface{}{
+			"type": "kv",
+		},
+	}
+
+	resp := map[string]interface{}{
+		"data": map[string]interface{}{
+			"secret": mounts,
+		},
+	}
+
+	enc := json.NewEncoder(w)
+	_ = enc.Encode(resp)
+}
+
+//nolint:gocyclo
+func vaultHandler(t *testing.T, files map[string]fakeSecret) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == "LIST" || (r.Method == http.MethodGet && r.URL.Query().Get("list") == "true") {
+			r.URL.Path += "/"
+
+			// transform back to list for simplicity
+			r.Method = "LIST"
+			vals := r.URL.Query()
+			vals.Del("list")
+			r.URL.RawQuery = vals.Encode()
+		}
+
+		data, ok := files[r.URL.Path]
+		if !ok {
+			w.WriteHeader(http.StatusNotFound)
+
+			return
+		}
+
+		q := r.URL.Query()
+		for k, v := range q {
+			if k == "method" {
+				assert.Equal(t, v[0], r.Method)
+			}
+		}
+
+		body := map[string]interface{}{}
+
+		if r.Body != nil {
+			dec := json.NewDecoder(r.Body)
+			_ = dec.Decode(&body)
+
+			defer r.Body.Close()
+
+			if p, ok := body["param"]; ok {
+				data.Param = p.(string)
+			}
+		}
+
+		switch r.Method {
+		case http.MethodGet:
+			assert.Empty(t, data.Param, r.URL)
+			assert.NotEmpty(t, data.Value, r.URL)
+		case http.MethodPost:
+			assert.NotEmpty(t, data.Param, r.URL)
+		case "LIST":
+			assert.NotEmpty(t, data.Keys, r.URL)
+		}
+
+		t.Logf("encoding %#v", data)
+
+		enc := json.NewEncoder(w)
+		_ = enc.Encode(map[string]interface{}{"data": data})
+	})
+}
+
+type fakeSecret struct {
+	Value string   `json:"value,omitempty"`
+	Param string   `json:"param,omitempty"`
+	Keys  []string `json:"keys,omitempty"`
+}
+
+func Server(t *testing.T) *api.Client {
+	files := map[string]fakeSecret{
+		"/v1/secret/":            {Keys: []string{"foo", "bar", "foo/"}},
+		"/v1/secret/foo":         {Value: "foo"},
+		"/v1/secret/bar":         {Value: "foo"},
+		"/v1/secret/foo/":        {Keys: []string{"foo", "bar", "bazDir/"}},
+		"/v1/secret/foo/foo":     {Value: "foo"},
+		"/v1/secret/foo/bar":     {Value: "foo"},
+		"/v1/secret/foo/bazDir/": {Keys: []string{"foo", "bar", "bazDir/"}},
+	}
+
+	mux := http.NewServeMux()
+
+	mux.HandleFunc("/v1/sys/internal/ui/mounts", mountHandler)
+	mux.Handle("/", vaultHandler(t, files))
+
+	return FakeVault(t, mux)
+}
+
+func FakeVault(t *testing.T, handler http.Handler) *api.Client {
+	srv := httptest.NewServer(handler)
+	t.Cleanup(srv.Close)
+
+	tr := &http.Transport{
+		Proxy: func(_ *http.Request) (*url.URL, error) {
+			return url.Parse(srv.URL)
+		},
+	}
+	httpClient := &http.Client{Transport: tr}
+	config := &api.Config{Address: srv.URL, HttpClient: httpClient}
+
+	c, _ := api.NewClient(config)
+
+	return c
+}

--- a/vaultfs/auth_test.go
+++ b/vaultfs/auth_test.go
@@ -10,12 +10,13 @@ import (
 	"testing"
 	"testing/fstest"
 
+	"github.com/hairyhenderson/go-fsimpl/internal/tests/fakevault"
 	"github.com/hashicorp/vault/api"
 	"github.com/stretchr/testify/assert"
 )
 
 func TestEnvAuthLogin(t *testing.T) {
-	v := fakeVaultServer(t)
+	v := fakevault.Server(t)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -85,7 +86,7 @@ func TestAppRoleAuthMethod(t *testing.T) {
 	mount := "approle"
 	token := "approletoken"
 
-	client := fakeVault(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	client := fakevault.FakeVault(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, "/v1/auth/"+mount+"/login", r.URL.Path)
 
 		out := map[string]interface{}{
@@ -157,7 +158,7 @@ func TestUserPassAuthMethod(t *testing.T) {
 		_ = enc.Encode(out)
 	})
 
-	client := fakeVault(t, mux)
+	client := fakevault.FakeVault(t, mux)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -194,7 +195,7 @@ func TestGitHubAuthMethod(t *testing.T) {
 	token := "sometoken"
 	ghtoken := "abcd1234"
 
-	client := fakeVault(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	client := fakevault.FakeVault(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, "/v1/auth/"+mount+"/login", r.URL.Path)
 
 		out := map[string]interface{}{

--- a/vaultfs/vaultauth/env_test.go
+++ b/vaultfs/vaultauth/env_test.go
@@ -2,17 +2,15 @@ package vaultauth
 
 import (
 	"context"
-	"encoding/json"
-	"net/http"
 	"testing"
 
-	"github.com/hashicorp/vault/api"
+	"github.com/hairyhenderson/go-fsimpl/internal/tests/fakevault"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
 func TestEnvAuthLogin(t *testing.T) {
-	v := fakeVaultServer(t)
+	v := fakevault.Server(t)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -24,69 +22,4 @@ func TestEnvAuthLogin(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, "foo", s.Auth.ClientToken)
 	assert.NotNil(t, m.(*compositeAuthMethod).chosen)
-}
-
-//nolint:funlen
-func fakeVaultServer(t *testing.T) *api.Client {
-	files := map[string]struct {
-		Value string   `json:"value,omitempty"`
-		Param string   `json:"param,omitempty"`
-		Keys  []string `json:"keys,omitempty"`
-	}{
-		"/v1/secret/":            {Keys: []string{"foo", "bar", "foo/"}},
-		"/v1/secret/foo":         {Value: "foo"},
-		"/v1/secret/bar":         {Value: "foo"},
-		"/v1/secret/foo/":        {Keys: []string{"foo", "bar", "bazDir/"}},
-		"/v1/secret/foo/foo":     {Value: "foo"},
-		"/v1/secret/foo/bar":     {Value: "foo"},
-		"/v1/secret/foo/bazDir/": {Keys: []string{"foo", "bar", "bazDir/"}},
-	}
-
-	return fakeVault(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.Method == "LIST" {
-			r.URL.Path += "/"
-		}
-
-		data, ok := files[r.URL.Path]
-		if !ok {
-			w.WriteHeader(http.StatusNotFound)
-
-			return
-		}
-
-		q := r.URL.Query()
-		for k, v := range q {
-			if k == "method" {
-				assert.Equal(t, v[0], r.Method)
-			}
-		}
-
-		body := map[string]interface{}{}
-
-		if r.Body != nil {
-			dec := json.NewDecoder(r.Body)
-			_ = dec.Decode(&body)
-
-			defer r.Body.Close()
-
-			if p, ok := body["param"]; ok {
-				data.Param = p.(string)
-			}
-		}
-
-		switch r.Method {
-		case http.MethodGet:
-			assert.Empty(t, data.Param, r.URL)
-			assert.NotEmpty(t, data.Value, r.URL)
-		case http.MethodPost:
-			assert.NotEmpty(t, data.Param, r.URL)
-		case "LIST":
-			assert.NotEmpty(t, data.Keys, r.URL)
-		}
-
-		t.Logf("encoding %#v", data)
-
-		enc := json.NewEncoder(w)
-		_ = enc.Encode(map[string]interface{}{"data": data})
-	}))
 }

--- a/vaultfs/vaultauth/github_test.go
+++ b/vaultfs/vaultauth/github_test.go
@@ -4,38 +4,19 @@ import (
 	"context"
 	"encoding/json"
 	"net/http"
-	"net/http/httptest"
-	"net/url"
 	"testing"
 
-	"github.com/hashicorp/vault/api"
+	"github.com/hairyhenderson/go-fsimpl/internal/tests/fakevault"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
-
-func fakeVault(t *testing.T, handler http.Handler) *api.Client {
-	srv := httptest.NewServer(handler)
-	t.Cleanup(srv.Close)
-
-	tr := &http.Transport{
-		Proxy: func(_ *http.Request) (*url.URL, error) {
-			return url.Parse(srv.URL)
-		},
-	}
-	httpClient := &http.Client{Transport: tr}
-	config := &api.Config{Address: srv.URL, HttpClient: httpClient}
-
-	c, _ := api.NewClient(config)
-
-	return c
-}
 
 func TestGitHubAuthMethod(t *testing.T) {
 	mount := "github"
 	token := "sometoken"
 	ghtoken := "abcd1234"
 
-	client := fakeVault(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	client := fakevault.FakeVault(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, "/v1/auth/"+mount+"/login", r.URL.Path)
 
 		out := map[string]interface{}{


### PR DESCRIPTION
Fixes #730 

- now caches the matching mount from the `sys/internal/ui/mounts` in the file
- uses the KVv2 client directly instead of making a raw request and munging the path
