### PR TITLE
fix(vaultfs): bug when Stat builds mount info from #738

### DIFF
--- a/autofs/lookup.go
+++ b/autofs/lookup.go
@@ -46,7 +46,7 @@ func (c *autoFS) New(u *url.URL) (fs.FS, error) {
 }
 
 func initMux() fsimpl.FSMux {
-	return sync.OnceValue[fsimpl.FSMux](func() fsimpl.FSMux {
+	return sync.OnceValue(func() fsimpl.FSMux {
 		mux := fsimpl.NewMux()
 		mux.Add(awsimdsfs.FS)
 		mux.Add(awssmfs.FS)


### PR DESCRIPTION
Missed a bug in #738 - Stat wasn't working properly when directly listing the mount endpoint.

Also a bit of refactoring to keep things easier to read...