### PR TITLE
fix(aws): Get region from IMDS when missing for awssmfs, awssmpfs, and blobfs (s3://)

### DIFF
--- a/internal/types.go
+++ b/internal/types.go
@@ -95,3 +95,10 @@ type WithHTTPClienter interface {
 type WithHeaderer interface {
 	WithHeader(headers http.Header) fs.FS
 }
+
+// WithIMDSFSer overrides the IMDS filesystem used by fs, if the filesystem
+// supports it (i.e. has a WithIMDSFS method). This can be used for overriding
+// the IMDS filesystem used by the fs to discover the region.
+type WithIMDSFSer interface {
+	WithIMDSFS(imdsfs fs.FS) fs.FS
+}


### PR DESCRIPTION
In the original v2 aws-sdk-go, it wasn't necessary to set an AWS region, but with v2, a region is always required (at least, for most APIs). This can either be done with environment variables (`AWS_REGION`, for example), or by a shared config. On EC2, however, it's customary to fall back to the instance metadata service (IMDS).

This is necessary for https://github.com/hairyhenderson/gomplate/issues/2180, for example.