### PR TITLE
fix(ci): add explicit permissions to benchmark workflow

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -5,6 +5,10 @@ on:
       - main
   pull_request:
 
+permissions:
+  pull-requests: write
+  contents: read
+
 jobs:
   benchmark:
     name: benchmark regression check


### PR DESCRIPTION
The benchmark workflow was failing on Dependabot PRs with a "Resource not accessible by integration" error when trying to post benchmark results. This was because Dependabot PRs have more restricted token permissions by default.

Fixes the failure that happened in #990 