### PR TITLE
fix(ci): need contents write perm for benchmark workflow

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -7,7 +7,7 @@ on:
 
 permissions:
   pull-requests: write
-  contents: read
+  contents: write
 
 jobs:
   benchmark:


### PR DESCRIPTION
I think this'll fix the failures in `main` since #1000 