### PR TITLE
fix(vault): properly treat kv2 mounts with legacy `generic` type as kv2

### DIFF
--- a/vaultfs/vault.go
+++ b/vaultfs/vault.go
@@ -277,6 +277,13 @@ type mountInfo struct {
 
 var _ fs.ReadDirFile = (*vaultFile)(nil)
 
+// isKVv2Mount reports whether mi describes a KV version 2 mount.
+// Vault has used both "kv" (current) and "generic" (legacy, pre-0.9.0) as the
+// type name for the same engine; both are treated identically when version==2.
+func isKVv2Mount(mi *mountInfo) bool {
+	return (mi.Type == "kv" || mi.Type == "generic") && mi.Options["version"] == "2"
+}
+
 func (f *vaultFile) request() (*api.KVSecret, *api.Secret, error) {
 	mountInfo, err := f.getMountInfo(f.ctx)
 	if err != nil {
@@ -285,7 +292,7 @@ func (f *vaultFile) request() (*api.KVSecret, *api.Secret, error) {
 
 	// it's a KVv2 Get operation with the right type, version, and especially if
 	// the secret path is set - otherwise it might need to be a list operation
-	if mountInfo.secretPath != "" && mountInfo.Type == "kv" && mountInfo.Options["version"] == "2" {
+	if mountInfo.secretPath != "" && isKVv2Mount(mountInfo) {
 		var kv *api.KVSecret
 
 		kv, err = f.kv2request(f.ctx, mountInfo.name, mountInfo.secretPath)
@@ -504,7 +511,7 @@ func (f *vaultFile) list() ([]string, error) {
 	p := path.Join(mi.name, mi.secretPath)
 	// if it's a KVv2 mount, we must inject "metadata/" into the path, because
 	// the logical client expects raw paths
-	if mi.Type == "kv" && mi.Options["version"] == "2" {
+	if isKVv2Mount(mi) {
 		p = path.Join(mi.name, "metadata", mi.secretPath)
 	}
 

--- a/vaultfs/vault.go
+++ b/vaultfs/vault.go
@@ -277,11 +277,17 @@ type mountInfo struct {
 
 var _ fs.ReadDirFile = (*vaultFile)(nil)
 
+// Vault has used both mountTypeKV (current) and mountTypeGeneric (legacy,
+// pre-0.9.0) as the type name for the same engine; both are treated
+// identically when version==2.
+const (
+	mountTypeKV      = "kv"
+	mountTypeGeneric = "generic"
+)
+
 // isKVv2Mount reports whether mi describes a KV version 2 mount.
-// Vault has used both "kv" (current) and "generic" (legacy, pre-0.9.0) as the
-// type name for the same engine; both are treated identically when version==2.
 func isKVv2Mount(mi *mountInfo) bool {
-	return (mi.Type == "kv" || mi.Type == "generic") && mi.Options["version"] == "2"
+	return (mi.Type == mountTypeKV || mi.Type == mountTypeGeneric) && mi.Options["version"] == "2"
 }
 
 func (f *vaultFile) request() (*api.KVSecret, *api.Secret, error) {

--- a/vaultfs/vault_test.go
+++ b/vaultfs/vault_test.go
@@ -418,6 +418,21 @@ func TestFindMountInfo(t *testing.T) {
 				},
 			},
 		},
+		{
+			// legacy "generic" type with version=2 (pre-Vault 0.9.0, same as kv+v2)
+			rawFilePath: "/v1/secret/a/b/c", mountName: "secret/",
+			mountOpts: map[string]any{
+				"type": "generic", "options": map[string]any{"version": "2"},
+			},
+			expected: &mountInfo{
+				secretPath: "/a/b/c",
+				name:       "secret/",
+				MountOutput: &api.MountOutput{
+					Type:    "generic",
+					Options: map[string]string{"version": "2"},
+				},
+			},
+		},
 	}
 
 	for _, d := range testdata {
@@ -430,6 +445,92 @@ func TestFindMountInfo(t *testing.T) {
 		require.NoError(t, err)
 		assert.Equal(t, d.expected, actual)
 	}
+}
+
+// genericV2Server returns a fake Vault server whose mount type is "generic"
+// with options[version]="2", simulating a pre-0.9.0 Vault KV v2 setup.
+// Secrets are served under the KV v2 data/metadata path layout.
+func genericV2Server(t *testing.T) *api.Client {
+	t.Helper()
+
+	// Map from request path to the JSON object returned inside {"data": ...}.
+	// LIST paths end with "/".
+	// Data paths use the KV v2 response layout: {"data": <payload>, "metadata": <meta>}.
+	responses := map[string]map[string]any{
+		"/v1/secret/metadata/":     {"keys": []string{"foo", "bar/"}},
+		"/v1/secret/metadata/bar/": {"keys": []string{"baz"}},
+		"/v1/secret/data/foo": {
+			"data":     map[string]any{"value": "foo"},
+			"metadata": map[string]any{"version": 1, "deletion_time": ""},
+		},
+		"/v1/secret/data/bar/baz": {
+			"data":     map[string]any{"value": "bar"},
+			"metadata": map[string]any{"version": 1, "deletion_time": ""},
+		},
+	}
+
+	mountH := func(w http.ResponseWriter, _ *http.Request) {
+		mounts := map[string]any{
+			"secret/": map[string]any{
+				"type":    "generic",
+				"options": map[string]any{"version": "2"},
+			},
+		}
+		resp := map[string]any{"data": map[string]any{"secret": mounts}}
+		_ = json.NewEncoder(w).Encode(resp)
+	}
+
+	secretH := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		p := r.URL.Path
+		if r.Method == "LIST" || (r.Method == http.MethodGet && r.URL.Query().Get("list") == "true") {
+			p += "/"
+		}
+
+		data, ok := responses[p]
+		if !ok {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+
+		_ = json.NewEncoder(w).Encode(map[string]any{"data": data})
+	})
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/v1/sys/internal/ui/mounts", mountH)
+	mux.Handle("/", secretH)
+
+	return fakevault.FakeVault(t, mux)
+}
+
+func TestReadFile_GenericV2Mount(t *testing.T) {
+	v := newRefCountedClient(genericV2Server(t))
+
+	fsys := fs.FS(newWithVaultClient(tests.MustURL("vault:///secret/"), v))
+	fsys = WithAuthMethod(TokenAuthMethod("blargh"), fsys)
+
+	b, err := fs.ReadFile(fsys, "foo")
+	require.NoError(t, err)
+	assert.Equal(t, `{"value":"foo"}`, string(b))
+
+	b, err = fs.ReadFile(fsys, "bar/baz")
+	require.NoError(t, err)
+	assert.Equal(t, `{"value":"bar"}`, string(b))
+}
+
+func TestReadDirFS_GenericV2Mount(t *testing.T) {
+	v := newRefCountedClient(genericV2Server(t))
+
+	fsys := fs.FS(newWithVaultClient(tests.MustURL("vault:///secret/"), v))
+	fsys = WithAuthMethod(TokenAuthMethod("blargh"), fsys)
+
+	de, err := fs.ReadDir(fsys, ".")
+	require.NoError(t, err)
+
+	names := make([]string, len(de))
+	for i, e := range de {
+		names[i] = e.Name()
+	}
+	assert.Equal(t, []string{"bar", "foo"}, names)
 }
 
 func TestWithConfig(t *testing.T) {

--- a/vaultfs/vault_test.go
+++ b/vaultfs/vault_test.go
@@ -422,13 +422,13 @@ func TestFindMountInfo(t *testing.T) {
 			// legacy "generic" type with version=2 (pre-Vault 0.9.0, same as kv+v2)
 			rawFilePath: "/v1/secret/a/b/c", mountName: "secret/",
 			mountOpts: map[string]any{
-				"type": "generic", "options": map[string]any{"version": "2"},
+				"type": mountTypeGeneric, "options": map[string]any{"version": "2"},
 			},
 			expected: &mountInfo{
 				secretPath: "/a/b/c",
 				name:       "secret/",
 				MountOutput: &api.MountOutput{
-					Type:    "generic",
+					Type:    mountTypeGeneric,
 					Options: map[string]string{"version": "2"},
 				},
 			},
@@ -448,8 +448,8 @@ func TestFindMountInfo(t *testing.T) {
 }
 
 // genericV2Server returns a fake Vault server whose mount type is "generic"
-// with options[version]="2", simulating a pre-0.9.0 Vault KV v2 setup.
-// Secrets are served under the KV v2 data/metadata path layout.
+// with options[version]="2", simulating a legacy mount that still reports the
+// pre-rename type name while using the KV v2 data/metadata path layout.
 func genericV2Server(t *testing.T) *api.Client {
 	t.Helper()
 
@@ -472,7 +472,7 @@ func genericV2Server(t *testing.T) *api.Client {
 	mountH := func(w http.ResponseWriter, _ *http.Request) {
 		mounts := map[string]any{
 			"secret/": map[string]any{
-				"type":    "generic",
+				"type":    mountTypeGeneric,
 				"options": map[string]any{"version": "2"},
 			},
 		}
@@ -489,6 +489,7 @@ func genericV2Server(t *testing.T) *api.Client {
 		data, ok := responses[p]
 		if !ok {
 			w.WriteHeader(http.StatusNotFound)
+
 			return
 		}
 
@@ -510,11 +511,11 @@ func TestReadFile_GenericV2Mount(t *testing.T) {
 
 	b, err := fs.ReadFile(fsys, "foo")
 	require.NoError(t, err)
-	assert.Equal(t, `{"value":"foo"}`, string(b))
+	assert.JSONEq(t, `{"value":"foo"}`, string(b))
 
 	b, err = fs.ReadFile(fsys, "bar/baz")
 	require.NoError(t, err)
-	assert.Equal(t, `{"value":"bar"}`, string(b))
+	assert.JSONEq(t, `{"value":"bar"}`, string(b))
 }
 
 func TestReadDirFS_GenericV2Mount(t *testing.T) {
@@ -530,6 +531,7 @@ func TestReadDirFS_GenericV2Mount(t *testing.T) {
 	for i, e := range de {
 		names[i] = e.Name()
 	}
+
 	assert.Equal(t, []string{"bar", "foo"}, names)
 }
 


### PR DESCRIPTION
This fix addresses the issues described in https://github.com/hairyhenderson/go-fsimpl/issues/1372 and https://github.com/hairyhenderson/gomplate/issues/2196 .

---

Extract a small helper `isKVv2Mount` that accepts both `"kv"` and `"generic"` as equivalent type names when `options[version] == "2"`, and replace the two inline type-checks in `request()` and `list()` with calls to it.

```go
// isKVv2Mount reports whether mi describes a KV version 2 mount.
// Vault has used both "kv" (current) and "generic" (legacy, pre-0.9.0) as the
// type name for the same engine; both are treated identically when version==2.
func isKVv2Mount(mi *mountInfo) bool {
    return (mi.Type == "kv" || mi.Type == "generic") && mi.Options["version"] == "2"
}