### PR TITLE
ci(renovate): enable automerge for minor/patch updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -6,5 +6,13 @@
   "osvVulnerabilityAlerts": true,
   "semanticCommits": "enabled",
   "semanticCommitType": "deps",
-  "semanticCommitScope": "{{manager}}"
+  "semanticCommitScope": "{{manager}}",
+  "platformAutomerge": true,
+  "packageRules": [
+    {
+      "matchUpdateTypes": ["minor", "patch"],
+      "minimumReleaseAge": "7 days",
+      "automerge": true
+    }
+  ]
 }


### PR DESCRIPTION
Auto-merge minor and patch dependency PRs via GitHub's native automerge, gated by a 7-day minimum release age as a safety valve. Major updates still require manual review.