### PR TITLE
fix(vaultfs): resolve auth mounts in mount discovery

### DIFF
--- a/vaultfs/vault.go
+++ b/vaultfs/vault.go
@@ -659,12 +659,7 @@ func (f *vaultFile) getMountInfo(ctx context.Context) (*mountInfo, error) {
 		return nil, fmt.Errorf("parse mount info: %w", err)
 	}
 
-	rawMounts, ok := s.Data["secret"].(map[string]any)
-	if !ok {
-		return nil, fmt.Errorf("unexpected mount info format: %#v", s.Data)
-	}
-
-	mi, err := findMountInfo(f.u.Path, rawMounts)
+	mi, err := findMountInfoFromData(f.u.Path, s.Data)
 	if err != nil {
 		return nil, err
 	}
@@ -679,34 +674,100 @@ func (f *vaultFile) getMountInfo(ctx context.Context) (*mountInfo, error) {
 }
 
 func findMountInfo(rawFilePath string, rawMounts map[string]any) (*mountInfo, error) {
-	for mountName, mountOpts := range rawMounts {
-		mountPrefix := path.Join("/v1", mountName)
+	return findMountInfoWithPrefix(rawFilePath, rawMounts, "/v1")
+}
 
-		if strings.HasPrefix(rawFilePath, mountPrefix) {
-			v, ok := mountOpts.(map[string]any)
-			if !ok {
-				return nil, fmt.Errorf("unexpected mount info format for %q: %#v", mountName, v)
+func findMountInfoWithPrefix(rawFilePath string, rawMounts map[string]any, prefix string) (*mountInfo, error) {
+	return findMountInfoInGroups(rawFilePath, []mountGroup{{prefix: prefix, mounts: rawMounts}})
+}
+
+type mountGroup struct {
+	prefix string
+	mounts map[string]any
+}
+
+func findMountInfoFromData(rawFilePath string, rawData map[string]any) (*mountInfo, error) {
+	groups := make([]mountGroup, 0, 2)
+
+	for _, g := range []struct {
+		key    string
+		prefix string
+	}{
+		{key: "secret", prefix: "/v1"},
+		{key: "auth", prefix: "/v1/auth"},
+	} {
+		rawMounts, ok := rawData[g.key]
+		if !ok {
+			continue
+		}
+
+		mounts, ok := rawMounts.(map[string]any)
+		if !ok {
+			return nil, fmt.Errorf("unexpected mount info format: %#v", rawData)
+		}
+
+		groups = append(groups, mountGroup{prefix: g.prefix, mounts: mounts})
+	}
+
+	if len(groups) == 0 {
+		return nil, fmt.Errorf("unexpected mount info format: %#v", rawData)
+	}
+
+	return findMountInfoInGroups(rawFilePath, groups)
+}
+
+func findMountInfoInGroups(rawFilePath string, groups []mountGroup) (*mountInfo, error) {
+	var (
+		bestMatch     *mountInfo
+		bestPrefixLen int
+	)
+
+	for _, group := range groups {
+		for mountName, mountOpts := range group.mounts {
+			mountPrefix := path.Join(group.prefix, mountName)
+
+			// Enforce a path-segment boundary: path.Join strips the trailing
+			// slash, so "kv/" yields prefix "/v1/kv". Without this check,
+			// that would incorrectly match "/v1/kv2/...".
+			if rawFilePath != mountPrefix && !strings.HasPrefix(rawFilePath, mountPrefix+"/") {
+				continue
 			}
 
-			mount := &api.MountOutput{Type: v["type"].(string)}
+			v, ok := mountOpts.(map[string]any)
+			if !ok {
+				return nil, fmt.Errorf("unexpected mount info format for %q: %#v", mountName, mountOpts)
+			}
+
+			mountType, ok := v["type"].(string)
+			if !ok {
+				return nil, fmt.Errorf("unexpected type field for mount %q: %T", mountName, v["type"])
+			}
+
+			mount := &api.MountOutput{Type: mountType}
 
 			opts, ok := v["options"].(map[string]any)
 			if ok {
 				mount.Options = make(map[string]string, len(opts))
-				for k, v := range opts {
-					mount.Options[k] = v.(string)
+				for k, ov := range opts {
+					sv, ok := ov.(string)
+					if !ok {
+						return nil, fmt.Errorf("unexpected option value type for mount %q key %q: %T", mountName, k, ov)
+					}
+					mount.Options[k] = sv
 				}
 			}
 
-			// build secretPath - it's the part after the mount name, including the
-			// / prefix
 			spath := strings.TrimPrefix(rawFilePath, mountPrefix)
+			match := &mountInfo{name: mountName, secretPath: spath, MountOutput: mount}
 
-			return &mountInfo{name: mountName, secretPath: spath, MountOutput: mount}, nil
+			if len(mountPrefix) > bestPrefixLen {
+				bestMatch = match
+				bestPrefixLen = len(mountPrefix)
+			}
 		}
 	}
 
-	return nil, nil
+	return bestMatch, nil
 }
 
 func createdTimeFromData(kvsec *api.KVSecret) time.Time {

--- a/vaultfs/vault.go
+++ b/vaultfs/vault.go
@@ -682,9 +682,14 @@ func findMountInfoWithPrefix(rawFilePath string, rawMounts map[string]any, prefi
 }
 
 type mountGroup struct {
-	prefix string
 	mounts map[string]any
+	prefix string
 }
+
+// mountGroupAuth is the "sys/internal/ui/mounts" response key for auth
+// mounts, addressed as /v1/auth/<mount> (as opposed to secret mounts, which
+// are addressed as /v1/<mount>).
+const mountGroupAuth = "auth"
 
 func findMountInfoFromData(rawFilePath string, rawData map[string]any) (*mountInfo, error) {
 	groups := make([]mountGroup, 0, 2)
@@ -694,7 +699,7 @@ func findMountInfoFromData(rawFilePath string, rawData map[string]any) (*mountIn
 		prefix string
 	}{
 		{key: "secret", prefix: "/v1"},
-		{key: "auth", prefix: "/v1/auth"},
+		{key: mountGroupAuth, prefix: "/v1/auth"},
 	} {
 		rawMounts, ok := rawData[g.key]
 		if !ok {
@@ -733,32 +738,10 @@ func findMountInfoInGroups(rawFilePath string, groups []mountGroup) (*mountInfo,
 				continue
 			}
 
-			v, ok := mountOpts.(map[string]any)
-			if !ok {
-				return nil, fmt.Errorf("unexpected mount info format for %q: %#v", mountName, mountOpts)
+			match, err := buildMountInfo(mountName, mountOpts, rawFilePath, mountPrefix)
+			if err != nil {
+				return nil, err
 			}
-
-			mountType, ok := v["type"].(string)
-			if !ok {
-				return nil, fmt.Errorf("unexpected type field for mount %q: %T", mountName, v["type"])
-			}
-
-			mount := &api.MountOutput{Type: mountType}
-
-			opts, ok := v["options"].(map[string]any)
-			if ok {
-				mount.Options = make(map[string]string, len(opts))
-				for k, ov := range opts {
-					sv, ok := ov.(string)
-					if !ok {
-						return nil, fmt.Errorf("unexpected option value type for mount %q key %q: %T", mountName, k, ov)
-					}
-					mount.Options[k] = sv
-				}
-			}
-
-			spath := strings.TrimPrefix(rawFilePath, mountPrefix)
-			match := &mountInfo{name: mountName, secretPath: spath, MountOutput: mount}
 
 			if len(mountPrefix) > bestPrefixLen {
 				bestMatch = match
@@ -768,6 +751,38 @@ func findMountInfoInGroups(rawFilePath string, groups []mountGroup) (*mountInfo,
 	}
 
 	return bestMatch, nil
+}
+
+func buildMountInfo(mountName string, mountOpts any, rawFilePath, mountPrefix string) (*mountInfo, error) {
+	v, ok := mountOpts.(map[string]any)
+	if !ok {
+		return nil, fmt.Errorf("unexpected mount info format for %q: %#v", mountName, mountOpts)
+	}
+
+	mountType, ok := v["type"].(string)
+	if !ok {
+		return nil, fmt.Errorf("unexpected type field for mount %q: %T", mountName, v["type"])
+	}
+
+	mount := &api.MountOutput{Type: mountType}
+
+	opts, ok := v["options"].(map[string]any)
+	if ok {
+		mount.Options = make(map[string]string, len(opts))
+
+		for k, ov := range opts {
+			sv, ok := ov.(string)
+			if !ok {
+				return nil, fmt.Errorf("unexpected option value type for mount %q key %q: %T", mountName, k, ov)
+			}
+
+			mount.Options[k] = sv
+		}
+	}
+
+	spath := strings.TrimPrefix(rawFilePath, mountPrefix)
+
+	return &mountInfo{name: mountName, secretPath: spath, MountOutput: mount}, nil
 }
 
 func createdTimeFromData(kvsec *api.KVSecret) time.Time {

--- a/vaultfs/vault_test.go
+++ b/vaultfs/vault_test.go
@@ -433,6 +433,14 @@ func TestFindMountInfo(t *testing.T) {
 				},
 			},
 		},
+		{
+			// path-segment boundary: "kv/" must not match "/v1/kv2/..."
+			rawFilePath: "/v1/kv2/secret", mountName: "kv/",
+			mountOpts: map[string]any{
+				"type": "kv", "options": map[string]any{"version": "2"},
+			},
+			expected: nil,
+		},
 	}
 
 	for _, d := range testdata {
@@ -533,6 +541,65 @@ func TestReadDirFS_GenericV2Mount(t *testing.T) {
 	}
 
 	assert.Equal(t, []string{"bar", "foo"}, names)
+}
+
+func TestFindMountInfoWithAuthPrefix(t *testing.T) {
+	rawMounts := map[string]any{
+		"token/": map[string]any{
+			"type": "token",
+		},
+	}
+
+	actual, err := findMountInfoWithPrefix("/v1/auth/token/lookup-self", rawMounts, "/v1/auth")
+	require.NoError(t, err)
+	assert.Equal(t, &mountInfo{
+		secretPath: "/lookup-self",
+		name:       "token/",
+		MountOutput: &api.MountOutput{
+			Type: "token",
+		},
+	}, actual)
+}
+
+func TestFindMountInfoWithPrefix_ChoosesLongestMatch(t *testing.T) {
+	rawMounts := map[string]any{
+		"k/": map[string]any{
+			"type": "kv",
+		},
+		"k/v/": map[string]any{
+			"type": "kv",
+		},
+	}
+
+	actual, err := findMountInfoWithPrefix("/v1/k/v/secret", rawMounts, "/v1")
+	require.NoError(t, err)
+	assert.Equal(t, "k/v/", actual.name)
+	assert.Equal(t, "/secret", actual.secretPath)
+}
+
+func TestFindMountInfoFromData(t *testing.T) {
+	rawData := map[string]any{
+		"secret": map[string]any{
+			"secret/": map[string]any{
+				"type": "kv",
+			},
+		},
+		"auth": map[string]any{
+			"token/": map[string]any{
+				"type": "token",
+			},
+		},
+	}
+
+	actual, err := findMountInfoFromData("/v1/auth/token/lookup-self", rawData)
+	require.NoError(t, err)
+	assert.Equal(t, &mountInfo{
+		name:       "token/",
+		secretPath: "/lookup-self",
+		MountOutput: &api.MountOutput{
+			Type: "token",
+		},
+	}, actual)
 }
 
 func TestWithConfig(t *testing.T) {


### PR DESCRIPTION
Changes introduced in 87b13670102570c2ce205b32e81cff360af7da5e inadvertently removed the ability to query the `auth` mount in vaultfs. For example, `auth/token/lookup-self` to get the current authenticated client's token. 

Previously, `getMountInfo` only parsed `data["secret"]` and matched mounts against `/v1/<mount>`. Since auth mounts live in `data["auth"]` and are addressed as `/v1/auth/<mount>`, this PR adds evaluation of mount groups with explicit prefixes:

- `secret → /v1`
- `auth → /v1/auth`

It retains the existing behavior of secret mounts (and adds some new tests).

(Alternatively, we could just fall back to the `auth` mount like in 63601c5d216905c03dbdf84b8eabf225841c8823 , but this parsing it out seems cleaner).