### PR TITLE
ci(renovate): enable automerge for digest updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -13,6 +13,10 @@
       "matchUpdateTypes": ["minor", "patch"],
       "minimumReleaseAge": "7 days",
       "automerge": true
+    },
+    {
+      "matchUpdateTypes": ["digest"],
+      "automerge": true
     }
   ]
 }


### PR DESCRIPTION
Docker digest bumps (e.g. #1390) weren't matched by the minor/patch automerge rule, so they sat waiting for manual merge despite passing all checks.