### PR TITLE
ci(renovate): delay major updates by 14 days before opening PRs

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -17,6 +17,10 @@
     {
       "matchUpdateTypes": ["digest"],
       "automerge": true
+    },
+    {
+      "matchUpdateTypes": ["major"],
+      "minimumReleaseAge": "7 days"
     }
   ]
 }


### PR DESCRIPTION
Gives time to surface breaking-change regressions before the PR lands